### PR TITLE
Vacuum engine drag cubes

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-0625.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-0625.cfg
@@ -363,6 +363,13 @@
   }
   %node_attach = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 3
   @attachRules = 1,1,1,0,0
+  
+  DRAG_CUBE
+	{
+		cube = Fairing, 0.2612,0.7597,0.4044, 0.2612,0.7597,0.5694, 0.2642,0.7653,0.4683, 0.2642,0.7668,0.4938, 0.2612,0.7561,0.4497, 0.2612,0.7565,0.4044, 0,-0.1771,0, 0.625,0.4491,0.625
+		cube = Clean, 0.2539,0.7776,0.4109, 0.2539,0.7774,0.5694, 0.1167,0.5871,0.4683, 0.1167,0.8246,0.4862, 0.2542,0.7739,0.4497, 0.2542,0.774,0.4109, 0,-0.1771,0, 0.625,0.4491,0.625
+	}
+  
   !EFFECTS {}
   EFFECTS
 	{
@@ -544,6 +551,7 @@
   MODULE
 	{
 		name = ModulePartVariants
+		useMultipleDragCubes = false
 		baseVariant = Size0
 		VARIANT
 		{
@@ -698,6 +706,7 @@
   @MODULE[ModuleJettison]
 	{
 		@jettisonName =  ShroudSparkBasic,ShroudSparkCompact
+		useMultipleDragCubes = true
 	}
 }
 

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-125.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-125.cfg
@@ -441,6 +441,12 @@
   !sound_rocket_hard = DELETE
   !sound_vent_soft = DELETE
   !sound_explosion_low = DELETE
+  
+  	DRAG_CUBE
+	{
+		cube = Fairing, 1.208,0.7553,0.7254, 1.208,0.7553,0.7254, 1.253,0.9242,0.2382, 1.253,0.6771,0.8475, 1.208,0.7546,0.7254, 1.208,0.7549,0.7254, -2.086E-06,-0.3681,1.788E-07, 1.268,0.9682,1.268
+		cube = Clean, 1.126,0.7562,0.7165, 1.126,0.7561,0.7165, 0.3048,0.9031,0.2075, 0.3048,0.9011,0.2075, 1.126,0.7553,0.7165, 1.126,0.7554,0.7165, 0,-0.3739,0, 1.25,0.9566,1.25
+	}
 
   !EFFECTS {}
   EFFECTS
@@ -526,6 +532,7 @@
   MODULE
   {
     name = ModulePartVariants
+	useMultipleDragCubes = false
     baseVariant = Size1
     VARIANT
     {
@@ -581,6 +588,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = Shroud909,Shroud909_Compact
+	useMultipleDragCubes = true
   }
 
   @MODULE[ModuleGimbal]

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
@@ -319,7 +319,13 @@
 	!sound_rocket_hard = DELETE
 	!sound_vent_soft = DELETE
 	!sound_explosion_low = DELETE
-
+	
+    DRAG_CUBE
+	{
+		cube = Fairing, 3.898,0.7731,1.901, 3.898,0.773,1.901, 3.297,0.7352,1.744, 3.311,0.6924,1.917, 3.895,0.7689,2.073, 3.895,0.7683,2.129, -0.001018,-0.6431,-0.002216, 3.418,1.717,3.42
+		cube = Clean, 3.871,0.7762,1.9, 3.871,0.7763,1.9, 2.683,0.5947,1.751, 2.686,0.6422,1.526, 3.874,0.7711,2.07, 3.874,0.7711,2.127, -0.0007027,-0.6431,0.0001873, 3.415,1.717,3.415
+	}
+	
   !MODEL {}
   MODEL
   {
@@ -588,12 +594,14 @@
   }
   @MODULE[ModuleJettison]
   {
-    @jettisonName = Poodle_Shroud, Poodle_Shroud_Compact
+    @jettisonName = Poodle_Shroud, Poodle_Shroud_Compact	
+	useMultipleDragCubes = true
   }
   MODULE
 	{
 		name = ModulePartVariants
-		baseVariant = Size2
+		baseVariant = Size2		
+		useMultipleDragCubes = false
 		VARIANT
 		{
 			name = Size2


### PR DESCRIPTION
This sets custom drag cubes for the Spark, Terrier and Poodle. 

It also sets these parts to use shroud-based drag cube switching, so it changes between "bare" and "shrouded" cubes based on the presence of the shroud, which makes more sense than part variant-based drag cube switching, given how they are most commonly used.

