### PR TITLE
Engine drag cubes part II

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-125.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-125.cfg
@@ -349,6 +349,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = Fairing125,Fairing25,FairingCompact
+	useMultipleDragCubes = false
   }
 
   @MODULE[ModuleGimbal]
@@ -859,6 +860,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = ShroudT30,ShroudT30_Compact
+	useMultipleDragCubes = false
   }
 
   !MODULE[FXModuleAnimateThrottle] {}
@@ -1124,6 +1126,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = ShroudT45,ShroudT45_Compact
+	useMultipleDragCubes = false
   }
 
   @MODULE[ModuleGimbal]

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
@@ -302,6 +302,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = Mainsail_Shroud,Mainsail_Shroud_Compact
+	useMultipleDragCubes = false
   }
 }
 
@@ -980,6 +981,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = Skipper_Shroud,Skipper_Shroud_Compact
+	useMultipleDragCubes = false
   }
 }
 

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-375.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-375.cfg
@@ -149,6 +149,7 @@
   @MODULE[ModuleJettison]
   {
     @jettisonName = Fairing375,Fairing375_Compact
+	useMultipleDragCubes = false
   }
 
   @MODULE[ModuleGimbal]

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-srb-125.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-srb-125.cfg
@@ -394,6 +394,7 @@
     !secondaryColor = DELETE
     !baseDisplayName = DELETE
     !baseThemeName = DELETE
+	useMultipleDragCubes = false
     VARIANT
     {
       name = White
@@ -429,6 +430,7 @@
   @MODULE[ModuleJettison]
 	{
 		@jettisonName =  ShroudSRB
+		useMultipleDragCubes = true
 	}
 }
 
@@ -538,6 +540,7 @@
     !secondaryColor = DELETE
     !baseDisplayName = DELETE
     !baseThemeName = DELETE
+	useMultipleDragCubes = false
     VARIANT
     {
       name = White
@@ -573,6 +576,7 @@
   @MODULE[ModuleJettison]
 	{
 		@jettisonName =  ShroudSRB
+		useMultipleDragCubes = true
 	}
 }
 // Separatron


### PR DESCRIPTION
Many engines were set to procedural drag cubes because they were using both ModulePartVariant and ModuleJettison to modify drag cubes; only one can be active at the same time so the system reverts to using procedural cubes.

This fixes that for 1.25m, 2.5m, and 3.75m engines, they now only use ModulePartVariant to modify drag cubes (further modifications to some these engines' drag cubes will most likely be necessary). The LV-N remains procedural because of its weird double shroud setup.

The Flea and Hammer SRBs were set to use ModuleJettison to modify drag cubes, as their variants were purely cosmetic.