### PR TITLE
Service bay drag cubes

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Patches/Payload/restock-service-bays.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Payload/restock-service-bays.cfg
@@ -9,73 +9,67 @@
 
   !mesh = DELETE
   !MODEL {}
-  MODEL {
+  MODEL
+  {
     model = ReStock/Assets/Payload/restock-service-bay-125-1
   }
-
   @MODULE[ModuleAnimateGeneric]
   {
     @animationName = DoorsOpen
   }
   @MODULE[ModuleSeeThroughObject]
   {
-	@transformName = NewBay125
-}
+    @transformName = NewBay125
+  }
 
   MODULE
-	{
-		name = ModulePartVariants
-		baseVariant = Opaque
-		VARIANT
-		{
-			name = Opaque
-			displayName = #LOC_Restock_variant-service-bay-opaque
-      primaryColor = #ffffff
-			secondaryColor = #ffffff
-			GAMEOBJECTS
-			{
-				ServiceBay125_Opaque = true
-				ServiceBay125 = false
-				ServiceBay125_Transparent = false
-				FloorColliders = true
-
-			}
-
-		}
+  {
+    name = ModulePartVariants
+    useMultipleDragCubes = false
+    baseVariant = Opaque
     VARIANT
-		{
-			name = Transparent
-			displayName = #LOC_Restock_variant-service-bay-transparent
+    {
+      name = Opaque
+      displayName = #LOC_Restock_variant-service-bay-opaque
       primaryColor = #ffffff
-			secondaryColor = #999999
-			GAMEOBJECTS
-			{
-				ServiceBay125_Opaque = false
-				ServiceBay125 = false
-				ServiceBay125_Transparent = true
-				FloorColliders = true
-			}
-
-		}
+      secondaryColor = #ffffff
+      GAMEOBJECTS
+      {
+        ServiceBay125_Opaque = true
+        ServiceBay125 = false
+        ServiceBay125_Transparent = false
+        FloorColliders = true
+      }
+    }
     VARIANT
-		{
-			name = Hollow
-			displayName = #LOC_Restock_variant-service-bay-hollow
+    {
+      name = Transparent
+      displayName = #LOC_Restock_variant-service-bay-transparent
       primaryColor = #ffffff
-			secondaryColor = #000000
-			GAMEOBJECTS
-			{
-				ServiceBay125_Opaque = false
-				ServiceBay125 = true
-				ServiceBay125_Transparent = false
-				FloorColliders = false
-			}
-
-		}
-
-
-
-	}
+      secondaryColor = #999999
+      GAMEOBJECTS
+      {
+        ServiceBay125_Opaque = false
+        ServiceBay125 = false
+        ServiceBay125_Transparent = true
+        FloorColliders = true
+      }
+    }
+    VARIANT
+    {
+      name = Hollow
+      displayName = #LOC_Restock_variant-service-bay-hollow
+      primaryColor = #ffffff
+      secondaryColor = #000000
+      GAMEOBJECTS
+      {
+        ServiceBay125_Opaque = false
+        ServiceBay125 = true
+        ServiceBay125_Transparent = false
+        FloorColliders = false
+      }
+    }
+  }
 }
 
 @PART[ServiceBay_250]
@@ -84,7 +78,8 @@
 
   !mesh = DELETE
   !MODEL {}
-  MODEL {
+  MODEL
+  {
     model = ReStock/Assets/Payload/restock-service-bay-25-1
   }
   @MODULE[ModuleAnimateGeneric]
@@ -94,105 +89,100 @@
   @MODULE[ModuleSeeThroughObject]
   {
 		@transformName = NewBay25
-	}
+  }
   MODULE
-	{
-		name = ModulePartVariants
-		baseVariant = Opaque
-		VARIANT
-		{
-			name = Opaque
-			displayName = #LOC_Restock_variant-service-bay-opaque
-      primaryColor = #ffffff
-			secondaryColor = #999999
-			GAMEOBJECTS
-			{
-				ServiceBay25_Opaque = true
-				ServiceBay25 = false
-				ServiceBay25_Transparent = false
-				FloorColliders = true
-
-			}
-
-		}
+  {
+    name = ModulePartVariants
+    useMultipleDragCubes = false
+    baseVariant = Opaque
     VARIANT
-		{
-			name = Transparent
-			displayName = #LOC_Restock_variant-service-bay-transparent
+    {
+      name = Opaque
+      displayName = #LOC_Restock_variant-service-bay-opaque
       primaryColor = #ffffff
-			secondaryColor = #999999
-			GAMEOBJECTS
-			{
-				ServiceBay25_Opaque = false
-				ServiceBay25 = false
-				ServiceBay25_Transparent = true
-				FloorColliders = true
-			}
-
-		}
+      secondaryColor = #999999
+      GAMEOBJECTS
+      {
+        ServiceBay25_Opaque = true
+        ServiceBay25 = false
+        ServiceBay25_Transparent = false
+        FloorColliders = true
+      }
+    }
     VARIANT
-		{
-			name = Hollow
-			displayName = #LOC_Restock_variant-service-bay-hollow
+    {
+      name = Transparent
+      displayName = #LOC_Restock_variant-service-bay-transparent
       primaryColor = #ffffff
-			secondaryColor = #000000
-			GAMEOBJECTS
-			{
-				ServiceBay25_Opaque = false
-				ServiceBay25 = true
-				ServiceBay25_Transparent = false
-				FloorColliders = false
-			}
+      secondaryColor = #999999
+      GAMEOBJECTS
+      {
+        ServiceBay25_Opaque = false
+        ServiceBay25 = false
+        ServiceBay25_Transparent = true
+        FloorColliders = true
+      }
+    }
+    VARIANT
+    {
+      name = Hollow
+      displayName = #LOC_Restock_variant-service-bay-hollow
+      primaryColor = #ffffff
+      secondaryColor = #000000
+      GAMEOBJECTS
+      {
+        ServiceBay25_Opaque = false
+        ServiceBay25 = true
+        ServiceBay25_Transparent = false
+        FloorColliders = false
+      }
+    }
+  }
 
-		}
-
-
-		}
-		MODULE
-	{
-		name = FXModuleLookAtConstraint
-
-		// Ringed
-		CONSTRAINLOOKFX
-		{
-			targetName = CylBottom001
-			rotatorsName = CylTop001
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylBottom002
-			rotatorsName = CylTop002
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylBottom003
-			rotatorsName = CylTop003
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylBottom004
-			rotatorsName = CylTop004
-		}
-
-		CONSTRAINLOOKFX
-		{
-			targetName = CylTop001
-			rotatorsName = CylBottom001
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylTop002
-			rotatorsName = CylBottom002
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylTop003
-			rotatorsName = CylBottom003
-		}
-		CONSTRAINLOOKFX
-		{
-			targetName = CylTop004
-			rotatorsName = CylBottom004
-		}
-	}
+  MODULE
+  {
+    name = FXModuleLookAtConstraint
+    
+    // Ringed
+    CONSTRAINLOOKFX
+    {
+      targetName = CylBottom001
+      rotatorsName = CylTop001
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylBottom002
+      rotatorsName = CylTop002
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylBottom003
+      rotatorsName = CylTop003
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylBottom004
+      rotatorsName = CylTop004
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylTop001
+      rotatorsName = CylBottom001
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylTop002
+      rotatorsName = CylBottom002
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylTop003
+      rotatorsName = CylBottom003
+    }
+    CONSTRAINLOOKFX
+    {
+      targetName = CylTop004
+      rotatorsName = CylBottom004
+    }
+  }
 }


### PR DESCRIPTION
This disables the variant-based drag cubes for the 1.25m and 2.5m service bays, allowing the animation module to generate drag cubes. As some of the variants are hollow this would have caused drag problems otherwise.

I also converted the file to 2 spaces instead of tabs, which were both mixed together. The actual changes are on lines 28 and 96.