### PR TITLE
removed numbers from the description

### DIFF
--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
@@ -10,7 +10,7 @@ Localization
   {
     // Engines
     #LOC_RestockPlus_restock-engine-corgi_title = KR-10A 'Corgi' Liquid Fuel Engine Cluster
-    #LOC_RestockPlus_restock-engine-corgi_description = Kerbodyne engineers have discovered that clustering can be an effective solution when you need more thrust, and don't want to add more boosters. This upper stage engine is very efficient as it takes advantage of a set of lovingly handcrafted, free range KR-10 Engines.
+    #LOC_RestockPlus_restock-engine-corgi_description = Kerbodyne engineers have discovered that clustering can be an effective solution when you need more thrust, and don't want to add more boosters. This upper stage engine is very efficient as it takes advantage of a set of four lovingly handcrafted engines.
     #LOC_RestockPlus_restock-engine-corgi_tags = orbit vac upper propuls sls rl10 eus restock kr 10a corgi
 
     #LOC_RestockPlus_restock-engine-boar_title = KR-1 'Boar' Liquid Fuel Engine
@@ -48,7 +48,7 @@ Localization
 
     // RCS
     #LOC_RestockPlus_restock-rcs-block-dual-1_title = RV-102 RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-dual-1_description = A spin on a classic, the 102 model removes two of the 105's engines for fewer confusing directions of thrust.
+    #LOC_RestockPlus_restock-rcs-block-dual-1_description = A spin on a classic, this model removes two of the 105's engines for fewer confusing directions of thrust.
     #LOC_RestockPlus_restock-rcs-block-dual-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate two pair dual rcs
     #LOC_RestockPlus_restock-rcs-block-triple-angled-1_title = RV-103 RCS Thruster Block
     #LOC_RestockPlus_restock-rcs-block-triple-angled-1_description = Apparently this is theoretically the most efficient RCS block.
@@ -57,14 +57,14 @@ Localization
     #LOC_RestockPlus_restock-rcs-block-quad-angled-1_description = Angling the thrusters on the standard RV-105 model can produce much better RCS translation in some spacecraft.
     #LOC_RestockPlus_restock-rcs-block-quad-angled-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate four lunar quad rcs
     #LOC_RestockPlus_restock-rcs-block-quint-1_title = RV-105-X RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-quint-1_description = Apparently for some space programs, four jets is just plain not enough. After in-the-field observations of PA-7s jammed into RV-105 blocks with electrical tape and pruning shears, STEADLER has released to 105-X with a fifth perpendicular nozzle.
+    #LOC_RestockPlus_restock-rcs-block-quint-1_description = Apparently for some space programs, four jets is just plain not enough. After in-the-field observations of the linear RCS Port jammed into RV-105 blocks with electrical tape and pruning shears, STEADLER has released to new RCS with a fifth perpendicular nozzle.
     #LOC_RestockPlus_restock-rcs-block-quint-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint rcs
 
     #LOC_RestockPlus_restock-rcs-single-mini-1_title = RC-1 RCS Linear RCS Port
     #LOC_RestockPlus_restock-rcs-single-mini-1_description = STEADLER Engineering has worked tirelessly and at considerable expense with Probodobodyne Corp on die shrinking processes for space compute hardware, with resultingly lower assembly line fatality rates. Out of this engineering sprung an oversized communications port which has been repurposed as a reaction control thruster.
     #LOC_RestockPlus_restock-rcs-single-mini-1_tags = restock control dock maneuver manoeuvre react rendezvous rotate stab steer translate single one rcs
     #LOC_RestockPlus_restock-rcs-block-dual-mini-1_title = RC-12 RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_description = A miniaturized RV-102, the RC-12 has a whole quarter of the thrust of its big brother.
+    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_description = A miniaturized two-thrusters-block has a whole quarter of the thrust of its big brother.
     #LOC_RestockPlus_restock-rcs-block-dual-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate tiny dual two pair rcs
     #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_title = RC-13 RCS Thruster Block
     #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_description = Check out the three thrusters on this one!
@@ -108,15 +108,15 @@ Localization
     #LOC_RestockPlus_restock-docking-375-1_tags = restock berth capture connect couple dock fasten join moor socket clamp grande
 
     #LOC_RestockPlus_restock-decoupler-1875-1_title = TD-18 Decoupler
-    #LOC_RestockPlus_restock-decoupler-1875-1_description = The TD-18 Stack Decoupler is a medium sized tool for splitting rockets.
+    #LOC_RestockPlus_restock-decoupler-1875-1_description = This Stack Decoupler is a medium sized tool for splitting rockets.
     #LOC_RestockPlus_restock-decoupler-1875-1_tags = restock break decouple explo kerbodyne separat split 
 
     #LOC_RestockPlus_restock-separator-1875-1_title = TS-18 Separator
-    #LOC_RestockPlus_restock-separator-1875-1_description = The TS-18 Stack Separator is a medium sized separator, much like the other separators. Unlike Decouplers, Separators will eject anything connected to themselves. This is good, as it removes the need to worry about which side needs to be pointed away from face. Try to not look at it too much though.
+    #LOC_RestockPlus_restock-separator-1875-1_description = This Stack Separator is a medium sized separator, much like the other separators. Unlike Decouplers, Separators will eject anything connected to themselves. This is good, as it removes the need to worry about which side needs to be pointed away from face. Try to not look at it too much though.
     #LOC_RestockPlus_restock-separator-1875-1_tags = restock break decouple separat split stag
 
     #LOC_RestockPlus_restock-decoupler-radial-tiny-1_title = TT-14 Radial Decoupler
-    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_description = The TT-14 is an extra small decoupler for very small separation events.
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_description = It's an extra small decoupler for very small separation events.
     #LOC_RestockPlus_restock-decoupler-radial-tiny-1_tags = restock break decouple separat split stag
 
     // Aerodynamic
@@ -130,7 +130,7 @@ Localization
 
     // Structural
     #LOC_RestockPlus_restock-adapter-hollow-25-375-1_title = Kerbodyne ADTP-2-3A
-    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the 2-3, which allows the storage of spacecraft components in its core.
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the Kerbodyne adapter, which allows the storage of spacecraft components in its core.
     #LOC_RestockPlus_restock-adapter-hollow-25-375-1_tags = connect frame scaffold adapt structur strut truss hollow skel carg restock adtp
 
     #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_title = Kerbodyne SKLE-2-3
@@ -144,16 +144,16 @@ Localization
 
     // Payload
     #LOC_RestockPlus_restock-fairing-base-0625-1_title = AE-FF0 Airstream Protective Shell (0.625m)
-    #LOC_RestockPlus_restock-fairing-base-0625-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! The AE-FF0 is an even tinier size available from FLOOYD.
+    #LOC_RestockPlus_restock-fairing-base-0625-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! This protective shell is an even tinier size available from FLOOYD.
     #LOC_RestockPlus_restock-fairing-base-0625-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 625
 
     #LOC_RestockPlus_restock-fairing-base-1875-1_title = AE-FF1-L Airstream Protective Shell (1.875m)
-    #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, the AE-FF1-L has become available.
+    #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, this protective shell has become available.
     #LOC_RestockPlus_restock-fairing-base-1875-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 875
 
     // Science
     #LOC_RestockPlus_restock-materialbay-radial-1_title = SC-9001R Radial Science Jr.
-    #LOC_RestockPlus_restock-materialbay-radial-1_description = The SC-9001R has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
+    #LOC_RestockPlus_restock-materialbay-radial-1_description = It has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
     #LOC_RestockPlus_restock-materialbay-radial-1_tags = bay experiment lab material research radial sandwich kracken kraken restock
 
     #LOC_RestockPlus_restock-goocanister-625-1_title = Mystery Goo™ Inline Containment Unit

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
@@ -57,14 +57,14 @@ Localization
     #LOC_RestockPlus_restock-rcs-block-quad-angled-1_description = Angling the thrusters on the standard RV-105 model can produce much better RCS translation in some spacecraft.
     #LOC_RestockPlus_restock-rcs-block-quad-angled-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate four lunar quad rcs
     #LOC_RestockPlus_restock-rcs-block-quint-1_title = RV-105-X RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-quint-1_description = Apparently for some space programs, four jets is just plain not enough. After in-the-field observations of the linear RCS Port jammed into RV-105 blocks with electrical tape and pruning shears, STEADLER has released to new RCS with a fifth perpendicular nozzle.
+    #LOC_RestockPlus_restock-rcs-block-quint-1_description = Apparently for some space programs, four jets is just plain not enough. After in-the-field observations of the linear RCS Port jammed into RV-105 blocks with electrical tape and pruning shears, STEADLER has released a new RCS block with a fifth perpendicular nozzle.
     #LOC_RestockPlus_restock-rcs-block-quint-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint rcs
 
     #LOC_RestockPlus_restock-rcs-single-mini-1_title = RC-1 RCS Linear RCS Port
     #LOC_RestockPlus_restock-rcs-single-mini-1_description = STEADLER Engineering has worked tirelessly and at considerable expense with Probodobodyne Corp on die shrinking processes for space compute hardware, with resultingly lower assembly line fatality rates. Out of this engineering sprung an oversized communications port which has been repurposed as a reaction control thruster.
     #LOC_RestockPlus_restock-rcs-single-mini-1_tags = restock control dock maneuver manoeuvre react rendezvous rotate stab steer translate single one rcs
     #LOC_RestockPlus_restock-rcs-block-dual-mini-1_title = RC-12 RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_description = A miniaturized two-thrusters-block has a whole quarter of the thrust of its big brother.
+    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_description = This miniaturized dual thruster block has a whole quarter of the thrust of its big brother.
     #LOC_RestockPlus_restock-rcs-block-dual-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate tiny dual two pair rcs
     #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_title = RC-13 RCS Thruster Block
     #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_description = Check out the three thrusters on this one!
@@ -108,11 +108,11 @@ Localization
     #LOC_RestockPlus_restock-docking-375-1_tags = restock berth capture connect couple dock fasten join moor socket clamp grande
 
     #LOC_RestockPlus_restock-decoupler-1875-1_title = TD-18 Decoupler
-    #LOC_RestockPlus_restock-decoupler-1875-1_description = This Stack Decoupler is a medium sized tool for splitting rockets.
+    #LOC_RestockPlus_restock-decoupler-1875-1_description = This stack decoupler is a medium sized tool for splitting rockets.
     #LOC_RestockPlus_restock-decoupler-1875-1_tags = restock break decouple explo kerbodyne separat split 
 
     #LOC_RestockPlus_restock-separator-1875-1_title = TS-18 Separator
-    #LOC_RestockPlus_restock-separator-1875-1_description = This Stack Separator is a medium sized separator, much like the other separators. Unlike Decouplers, Separators will eject anything connected to themselves. This is good, as it removes the need to worry about which side needs to be pointed away from face. Try to not look at it too much though.
+    #LOC_RestockPlus_restock-separator-1875-1_description = This stack separator is a medium sized separator, much like the other separators. Unlike Decouplers, Separators will eject anything connected to themselves. This is good, as it removes the need to worry about which side needs to be pointed away from face. Try to not look at it too much though.
     #LOC_RestockPlus_restock-separator-1875-1_tags = restock break decouple separat split stag
 
     #LOC_RestockPlus_restock-decoupler-radial-tiny-1_title = TT-14 Radial Decoupler
@@ -130,7 +130,7 @@ Localization
 
     // Structural
     #LOC_RestockPlus_restock-adapter-hollow-25-375-1_title = Kerbodyne ADTP-2-3A
-    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the Kerbodyne adapter, which allows the storage of spacecraft components in its core.
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the other Kerbodyne adapter, which allows the storage of spacecraft components in its core.
     #LOC_RestockPlus_restock-adapter-hollow-25-375-1_tags = connect frame scaffold adapt structur strut truss hollow skel carg restock adtp
 
     #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_title = Kerbodyne SKLE-2-3
@@ -148,12 +148,12 @@ Localization
     #LOC_RestockPlus_restock-fairing-base-0625-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 625
 
     #LOC_RestockPlus_restock-fairing-base-1875-1_title = AE-FF1-L Airstream Protective Shell (1.875m)
-    #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, this protective shell has become available.
+    #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, this protective shell has recently become available.
     #LOC_RestockPlus_restock-fairing-base-1875-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 875
 
     // Science
     #LOC_RestockPlus_restock-materialbay-radial-1_title = SC-9001R Radial Science Jr.
-    #LOC_RestockPlus_restock-materialbay-radial-1_description = It has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
+    #LOC_RestockPlus_restock-materialbay-radial-1_description = The radial variant of the Science Jr. has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
     #LOC_RestockPlus_restock-materialbay-radial-1_tags = bay experiment lab material research radial sandwich kracken kraken restock
 
     #LOC_RestockPlus_restock-goocanister-625-1_title = Mystery Goo™ Inline Containment Unit


### PR DESCRIPTION
 * it makes titles and descriptions independent. 
Sometimes I encounter old mods, where descriptions links to parts, which already not there (was renamed)
 * ~~also it helps with my Community Parts Titles: I could change titles, without overriding also descriptions~~