### PR TITLE
Typo in en-us.cfg localization

### DIFF
--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/en-us.cfg
@@ -45,7 +45,7 @@ Localization
     #LOC_RestockPlus_restock-engine-boar_description = The single Boar is slightly more efficient than its dual counterpart, and provides, logically, half the thrust. Due to a less integrated set of mounting points, there is a slight decrease in raw thrust-to-weight ratio.
     #LOC_RestockPlus_restock-engine-boar_tags = ascent main propuls lower sls dynetics f1b restock kr1 boar
 
-    #LOC_RestockPlus_restock-engine-cherenkov_title = LV-N410 'Cherenkov' Atomic Rocker Motor
+    #LOC_RestockPlus_restock-engine-cherenkov_title = LV-N410 'Cherenkov' Atomic Rocket Motor
     #LOC_RestockPlus_restock-engine-cherenkov_description = By popular demand, Rockomax has brought a powerful large nuclear engine to market. Like its smaller cousin the Nerv, it runs on only Liquid Fuel. As a result of a large development budget, gimballing mechanisms have been installed on the turbopump exhaust ducts, allowing limited vectored thrust abilities.
     #LOC_RestockPlus_restock-engine-cherenkov_tags = active atom efficient engine inter liquid (cherenkov nuclear nuke orbit propuls radio reactor vacuum restock
 


### PR DESCRIPTION
Fixed typo in LV-N410 'Cherenkov' Atomic Rocket Motor