### PR TITLE
French localization updated to KSP 1.10.1/restock 1.2.0

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Localization/fr-fr.cfg
+++ b/Distribution/Restock/GameData/ReStock/Localization/fr-fr.cfg
@@ -1,3 +1,6 @@
+// Courtesy of Challyss of the KSP forums.
+// Additional translation by vinix38.
+//
 // Proposed format:
 //   #LOC_Restock_partconfigname_fieldname
 // eg.


### PR DESCRIPTION
Added missing French localization in restock 1.2.0. No major change.