### PR TITLE
Pre-rotate the anchor transform

### DIFF
--- a/Source/Restock/ModuleRestockLaunchClamp.cs
+++ b/Source/Restock/ModuleRestockLaunchClamp.cs
@@ -22,6 +22,7 @@ namespace Restock
         public LaunchClampGirderFactory girderFactory;
 
         private int _girderSegments;
+        private Quaternion towerRot;
 
         private Material _girderMaterial;
         private Matrix4x4[] _girderMatrices;
@@ -63,10 +64,26 @@ namespace Restock
                     girderFactory.Initialize(girderMesh, girderSegmentHeight, maxSegments);
                 }
             }
+
+            if (node.HasValue ("towerRot"))
+            {
+                string rot = node.GetValue ("towerRot");
+                towerRot = KSPUtil.ParseQuaternion (rot);
+            }
             
             _girderSegments = 1;
 
             base.OnLoad(node);
+        }
+
+        public void RotateTower ()
+        {
+            // transforms found in OnLoad
+            float height = Vector3.Distance (towerAnchor.position, towerStretch.position);
+            //Debug.Log($"[ModuleRestockLaunchClamp] RotateTower: {height} {towerRot}");
+            towerPivot.localRotation = towerRot;
+            towerAnchor.localRotation = towerRot;
+            towerAnchor.position = towerStretch.position - towerStretch.up * height;
         }
 
         public override void OnStart(StartState state)


### PR DESCRIPTION
This is the launch clamp side of the fix for the EL-ReStock launch clamp
compatibility issue. The issue was reported in the EL thread and started
out as issues with getting the build cost but after fixing that, had
issues with the clamps extending properly when built at a survey site.
The bulk of the fix for that is (or will be) in EL, but this change is
for handling rotated clamps: it points the tower in the correct (editor)
direction prior to the tower being extended.