### PR TITLE
Set entryCost to zero on TechHidden parts

### DIFF
--- a/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Aero/1875/restock-nosecone-1875-1.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Aero/1875/restock-nosecone-1875-1.cfg
@@ -18,7 +18,7 @@ PART
   node_stack_bottom = 0.0, -0.94, 0, 0.0, -1.0, 0.0, 1
   // Tech
   TechRequired = aerodynamicSystems
-  entryCost = 4200
+  entryCost = 0
   // Info
   cost = 480
   category = none

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Coupling/0625/restock-claw-625-1.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Coupling/0625/restock-claw-625-1.cfg
@@ -17,7 +17,7 @@ PART
   node_attach = 0.0, -0.01, 0.0, 0.0, -1.0, 0.0, 0
   node_stack_bottom = 0.0, -0.06, 0.0, 0.0, -1.0, 0.0, 0
   TechRequired = actuators
-  entryCost = 4000
+  entryCost = 0
   cost = 350
   mass = 0.03
   category = none

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Patches/MakingHistoryPartHiding.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Patches/MakingHistoryPartHiding.cfg
@@ -3,6 +3,7 @@
 @PART[*]:HAS[#MHReplacement[True]]:FOR[zzReStockPlus]:NEEDS[SquadExpansion/MakingHistory]
 {
   %TechHidden = True
+  @entryCost = 0
   @category = none
   @subcategory = 0
   !MODULE[ModuleTestSubject] {}


### PR DESCRIPTION
A TechHidden part's entryCost isn't included in the price shown on the tech node's "purchase all parts" button, but clicking the button actually charges the player for hidden parts nonetheless.  This is a bug in the game, but it has a simple workaround: set entryCost to zero on parts that have the TechHidden flag.  (Squad's deprecated parts do this too.)