### PR TITLE
Add missing stage and deploy workflow steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,11 @@ jobs:
       run: python build-deploy/src/package.py --f "Distribution/Restock/.mod_data.yml"  
     - name: Building RestockPlus
       run: python build-deploy/src/package.py --f "Distribution/RestockPlus/.mod_data.yml"  
-    - name: Staging package
+    - name: Staging Restock
       run: python build-deploy/src/stage.py --f "Distribution/Restock/.mod_data.yml" # Run the staging script
+    - name: Staging RestockPlus
+      run: python build-deploy/src/stage.py --f "Distribution/RestockPlus/.mod_data.yml" # Run the staging script
     - name: Deploying Restock
+      run: python build-deploy/src/deploy.py --f "Distribution/Restock/.mod_data.yml" # Deploy package to spacedock, curse, github
+    - name: Deploying RestockPlus
       run: python build-deploy/src/deploy.py --f "Distribution/RestockPlus/.mod_data.yml" # Deploy package to spacedock, curse, github


### PR DESCRIPTION
## Problem

@Poodmund mentioned on the forum that there was a problem with this project's GitHub Actions:

![image](https://user-images.githubusercontent.com/1559108/105399288-07205880-5be9-11eb-918a-318180ec4491.png)

## Cause

Looking at the yml files and the build-deploy project, it looks like some steps are missing. Both Restock and RestockPlus are built, but then only Restock is staged and only RestockPlus is deployed.

## Changes

Now it will build both, stage both, and deploy both.