### PR TITLE
Missing brackets {}

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Patches/Ground/restock-wheels.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Ground/restock-wheels.cfg
@@ -115,7 +115,7 @@
     @damagedTransformName = WheelBusted
     @undamagedTransformName = Wheel
   }
-  !MODULE[FXModuleLookAtConstraint]
+  !MODULE[FXModuleLookAtConstraint]{}
   MODULE
   {
     name = ModuleRestockConstraints


### PR DESCRIPTION
//RoveMax Model M1
!MODULE[FXModuleLookAtConstraint] not being applied, because of missing brackets