### PR TITLE
Add Japanese localization

### DIFF
--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/ja.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/ja.cfg
@@ -1,0 +1,606 @@
+// Proposed format:
+//   #LOC_RestockPlus_partconfigname_fieldname
+// eg.
+//   #LOC_RestockPlus_restock-engine-375-3_title = ...
+//   #LOC_RestockPlus_restock-engine-375-3_description = ...
+
+Localization
+{
+  en-us
+  {
+
+    // AGENCIES
+    // ==========
+    #LOC_RestockPlus_agency_paperclips = Universal Paperclips
+
+    // ACTIONS AND BUTTONS
+    // ===================
+    #LOC_RestockPlus_light_rotate_on = Pivoted
+    #LOC_RestockPlus_light_rotate_off = Base Rotation
+    #LOC_RestockPlus_light_rotate_toggle = Rotate Light
+
+    #LOC_RestockPlus_launch_clamp_extended_on = Extended
+    #LOC_RestockPlus_launch_clamp_extended_off = Clamp Extension
+    #LOC_RestockPlus_launch_clamp_extended_toggle = Extend Clamp
+
+    #LOC_RestockPlus_airlock_inflate = Inflate Airlock
+    #LOC_RestockPlus_airlock_deflate = Deflate Airlock
+    #LOC_RestockPlus_airlock_toggle = Toggle Airlock
+
+    // IVA SEATS
+    // =========
+    #LOC_RestockPlus-seat-pilot = Pilot's Seat
+    #LOC_RestockPlus-seat-copilot= Co-Pilot's Seat
+
+
+    // ENGINES
+    // =======
+    // 3.75m
+    #LOC_RestockPlus_restock-engine-corgi_title = KR-10A 'Corgi' Liquid Fuel Engine Cluster
+    #LOC_RestockPlus_restock-engine-corgi_description = Kerbodyne engineers have discovered that clustering can be an effective solution when you need more thrust, and don't want to add more boosters. This upper stage engine is very efficient as it takes advantage of a set of four lovingly handcrafted engines.
+    #LOC_RestockPlus_restock-engine-corgi_tags = orbit vac upper propuls sls rl10 eus restock kr 10a corgi
+
+    // 2.5m
+    #LOC_RestockPlus_restock-engine-boar_title = KR-1 'Boar' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-boar_description = The single Boar is slightly more efficient than its dual counterpart, and provides, logically, half the thrust. Due to a less integrated set of mounting points, there is a slight decrease in raw thrust-to-weight ratio.
+    #LOC_RestockPlus_restock-engine-boar_tags = ascent main propuls lower sls dynetics f1b restock kr1 boar
+
+    #LOC_RestockPlus_restock-engine-cherenkov_title = LV-N410 'Cherenkov' Atomic Rocket Motor
+    #LOC_RestockPlus_restock-engine-cherenkov_description = By popular demand, Rockomax has brought a powerful large nuclear engine to market. Like its smaller cousin the Nerv, it runs on only Liquid Fuel. As a result of a large development budget, gimballing mechanisms have been installed on the turbopump exhaust ducts, allowing limited vectored thrust abilities.
+    #LOC_RestockPlus_restock-engine-cherenkov_tags = active atom efficient engine inter liquid (cherenkov nuclear nuke orbit propuls radio reactor vacuum restock
+
+    // 1.875m
+    #LOC_RestockPlus_restock-engine-srb-anvil_title = STS-1 'Anvil' Solid Rocket Booster
+    #LOC_RestockPlus_restock-engine-srb-anvil_description = Discontinued due to component shortages. This colossal solid rocket booster has more than enough power to be used to push lower thrust cores really high up or even be used as a core stage, if your engineers feel that the unstable explosive combustion's spine-tingling rumble could be harnessed as a back massage function for bored Kerbonauts.
+    #LOC_RestockPlus_restock-engine-srb-anvil_tags = a moar (more motor rocket shuttle ssrb srb restock anvil
+
+    #LOC_RestockPlus_restock-engine-srb-castor_title = TCK-2 'Castor' Solid Rocket Booster
+    #LOC_RestockPlus_restock-engine-srb-castor_description = This medium solid rocket booster has more than enough power to be used to push lower thrust cores really high up or even be used as a core stage, if your engineers feel that the unstable explosive combustion's spine-tingling rumble could be harnessed as a back massage function for bored Kerbonauts.
+    #LOC_RestockPlus_restock-engine-srb-castor_tags = a moar (more motor rocket shuttle ssrb srb restock castor
+
+    #LOC_RestockPlus_restock-engine-ursa_title = RK-107 'Ursa' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-ursa_description = Though the Ursa is bearish on gimbal mechanisms, it is fairly powerful and does simple, effective duty as a booster engine.
+    #LOC_RestockPlus_restock-engine-ursa_tags = fueltank ?lfo liquid oxidizer propellant rocket (ursa restock
+
+    #LOC_RestockPlus_restock-engine-caravel_title = UR-2 'Caravel' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-caravel_description = The Caravel easily sails into the winds of interplanetary space with average efficiency and thrust.
+    #LOC_RestockPlus_restock-engine-caravel_tags = fueltank ?lfo liquid oxidizer propellant rocket (caravel paperclip restock
+
+    #LOC_RestockPlus_restock-engine-schnauzer_title = UR-137 'Schnauzer' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-schnauzer_description = The Schnauzer has a large snout - er, bell, and as such functions majestically as a upper stage engine.
+    #LOC_RestockPlus_restock-engine-schnauzer_tags = fueltank ?lfo liquid oxidizer propellant rocket paperclip (schanuzer restock
+
+    #LOC_RestockPlus_restock-engine-galleon_title = UR-1 'Galleon' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-galleon_description = Set sail on the winds of space with your first stage propelled by the might of the Galleon! A modern ship of the line, this engine is a powerful booster.
+    #LOC_RestockPlus_restock-engine-galleon_tags = ascent main propuls lower paperclip restock ur1 (galleon f1 saturn
+
+    // 1.25m
+    #LOC_RestockPlus_restock-engine-pug_title = LV-303 'Pug' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-pug_description = What a cute little engine! All dressed up and ready for Baby's First Upper Stage.
+    #LOC_RestockPlus_restock-engine-pug_tags = orbit vac upper propuls restock 303 pug
+
+    #LOC_RestockPlus_restock-engine-valiant_title = LV-T15 'Valiant' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-valiant_description = The first (well, the first that didn't regularly explode) model in the famed LV series of engines. Just enough to get you flying, and it even offers such startling amenities as "throttle" and "gimbal".
+    #LOC_RestockPlus_restock-engine-valiant_tags = ascent main propuls lower sls restock t15 valiant
+
+    // 0.625m
+    #LOC_RestockPlus_restock-engine-torch_title = Mk-1H 'Torch' Liquid Fuel Engine
+    #LOC_RestockPlus_restock-engine-torch_description = When your booster is small and needs a real kick, the Torch's ability to produce high temperature gases as a prodigious rate will do you well.
+    #LOC_RestockPlus_restock-engine-torch_tags = ascent main propuls lower titan restock mk1h torch
+
+    #LOC_RestockPlus_restock-engine-srb-mallet_title = RT-1 'Mallet' Solid Rocket Booster
+    #LOC_RestockPlus_restock-engine-srb-mallet_description = Discontinued due to component shortages. The small Mallet answers the demand for miniature, compact SRBs suitable for additional booster assist or stack mounting for small launchers. The KSC's staff janitor, one O. Trag Kerman, has even proposed strapping dozens of them together to make super cheap vehicles!
+    #LOC_RestockPlus_restock-engine-srb-mallet_tags = moar (more motor rocket srb restock mallet
+
+    #LOC_RestockPlus_restock-engine-srb-striker_title = RT-2 'Striker' Solid Rocket Booster
+    #LOC_RestockPlus_restock-engine-srb-striker_description = Discontinued due to component shortages. Extending the Mallet with additional segments can provide more boom than your integration team knows what to do with!
+    #LOC_RestockPlus_restock-engine-srb-striker_tags = a moar (more motor rocket srb restock striker
+
+    #LOC_RestockPlus_restock-engine-les-2_title = Launch Escape System Jr.
+    #LOC_RestockPlus_restock-engine-les-2_description = A smaller solid rocket tower for yeeting crew away from certain death.
+    #LOC_RestockPlus_restock-engine-les-2_tags = abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv restock junior 625
+
+    // Radial
+    #LOC_RestockPlus_restock-engine-panda_title = RK-1 'Trash Panda' Vernier Engine
+    #LOC_RestockPlus_restock-engine-panda_description = This small engine has a very large single axis gimbal mechanism which allows excellent control at all flight regimes.
+    #LOC_RestockPlus_restock-engine-panda_tags = restock fueltank ?lfo liquid oxidizer propellant rocket (panda
+
+    // CONTROL
+    // =======
+
+    // Reaction wheels
+    #LOC_RestockPlus_restock-reactionwheel-radial-1_title = Small Radial Gyroscope
+    #LOC_RestockPlus_restock-reactionwheel-radial-1_description = Steadler's small radial gyroscope provides a small amount of torque but with greater power efficiency, allowing even large stations to maintain attitude with minimal power. We're still not entirely sure how gyroscopes work, but this one allows torque on all three axes.
+    #LOC_RestockPlus_restock-reactionwheel-radial-1_tags = cmg command control fly gyro moment react stab steer torque magic_spinny_thing restock
+
+    #LOC_RestockPlus_restock-reactionwheel-1875-1_title = Medium Reaction Wheel Assembly
+    #LOC_RestockPlus_restock-reactionwheel-1875-1_description = We purchased several of these gyroscope modules to ensure we could accurately control our medium sized rockets in all phases of flight.
+    #LOC_RestockPlus_restock-reactionwheel-1875-1_tags = restock cmg command control fly gyro moment react stab steer torque magic_spinny_thing
+
+    // RCS
+
+    #LOC_RestockPlus_restock-rcs-block-multi-2_title =  RV-105-A RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-multi-2_description = An angled variant of the RV-105 RCS block, available in multiple configurations.
+    #LOC_RestockPlus_restock-rcs-block-multi-2_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint four quad triple three dual two rcs
+    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_title =  RV-1X-A RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_description = An angled variant of the RV-1X RCS block, available in multiple configurations.
+    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint four quad triple three dual two rcs
+
+    #LOC_RestockPlus_rcs_variant_5x = 5-horn
+    #LOC_RestockPlus_rcs_variant_4x = 4-horn
+    #LOC_RestockPlus_rcs_variant_3x = 3-horn
+    #LOC_RestockPlus_rcs_variant_2x = 2-horn
+
+    #LOC_RestockPlus_restock-rcs-block-dual-1_title = RV-102 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-dual-1_description = A spin on a classic, this model removes two of the 105's engines for fewer confusing directions of thrust.
+    #LOC_RestockPlus_restock-rcs-block-dual-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate two pair dual rcs
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-1_title = RV-103 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-1_description = Apparently this is theoretically the most efficient RCS block.
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate three triple rcs
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-1_title = RV-105-A RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-1_description = Angling the thrusters on the standard RV-105 model can produce much better RCS translation in some spacecraft.
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate four lunar quad rcs
+    #LOC_RestockPlus_restock-rcs-block-quint-1_title = RV-105-X RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-quint-1_description = Apparently for some space programs, four jets is just plain not enough. After in-the-field observations of the linear RCS Port jammed into RV-105 blocks with electrical tape and pruning shears, STEADLER has released a new RCS block with a fifth perpendicular nozzle.
+    #LOC_RestockPlus_restock-rcs-block-quint-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint rcs
+
+    // Mini RCS
+    #LOC_RestockPlus_restock-rcs-single-mini-1_title = RC-1 RCS Linear RCS Port
+    #LOC_RestockPlus_restock-rcs-single-mini-1_description = STEADLER Engineering has worked tirelessly and at considerable expense with Probodobodyne Corp on die shrinking processes for space compute hardware, with resultingly lower assembly line fatality rates. Out of this engineering sprung an oversized communications port which has been repurposed as a reaction control thruster.
+    #LOC_RestockPlus_restock-rcs-single-mini-1_tags = restock control dock maneuver manoeuvre react rendezvous rotate stab steer translate single one rcs
+    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_title = RC-12 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_description = This miniaturized dual thruster block has a whole quarter of the thrust of its big brother.
+    #LOC_RestockPlus_restock-rcs-block-dual-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate tiny dual two pair rcs
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_title = RC-13 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_description = Check out the three thrusters on this one!
+    #LOC_RestockPlus_restock-rcs-block-triple-angled-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate triple tiny three rcs
+    #LOC_RestockPlus_restock-rcs-block-quad-mini-1_title = RC-14 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-quad-mini-1_description = A really basic RCS system block, but really small.
+    #LOC_RestockPlus_restock-rcs-block-quad-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate four tiny quad rcs
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-mini-1_title = RC-14-A RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-mini-1_description = This angled block, is, you guessed it, canted slightly for better four way efficiency.
+    #LOC_RestockPlus_restock-rcs-block-quad-angled-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate four tiny quad rcs
+    #LOC_RestockPlus_restock-rcs-block-quint-mini-1_title = RC-15 RCS Thruster Block
+    #LOC_RestockPlus_restock-rcs-block-quint-mini-1_description = Miniaturizing five RCS jets into one block wasn't easy, but we have you covered here - if covered refers to the fine misting of toxic gases that qualification models of these thrusters applied to several interns.
+    #LOC_RestockPlus_restock-rcs-block-quint-mini-1_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five tiny quint rcs
+
+    // FUEL TANKS
+    // ==========
+
+    // Radial
+    #LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_title = Stratus-V Miniature Monopropellant Tank
+    #LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_description = A teensy, tiny RCS fuel tank for microscale satellites and decorating larger ships.
+    #LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_tags = restock fuel fueltank mono propellant rcs stratus
+
+    // Probe
+    #LOC_RestockPlus_restock-fuel-tank-probe-1_title = PRBE-9 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-probe-1_description = A set of four capsule-shaped tanks holding fuel for your tiny probe needs.
+    #LOC_RestockPlus_restock-fuel-tank-probe-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank probe lro tiny
+    #LOC_RestockPlus_restock-fuel-tank-probe-2_title = PRBE-4 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-probe-2_description = A short collection of four spherical tanks that works well as a tiny probe propellant tank.
+    #LOC_RestockPlus_restock-fuel-tank-probe-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank probe lro tiny
+
+    // 0.625m
+    #LOC_RestockPlus_restock-fuel-tank-0625-1_title = Oscar-E Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-0625-1_description = Capping off the Oscars is this large fuel tank. Gold statue not included.
+    #LOC_RestockPlus_restock-fuel-tank-0625-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
+    #LOC_RestockPlus_restock-fuel-tank-0625-2_title = Oscar-D Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-0625-2_description = A medium size Oscar series tank. Useful for landers or small satellite lifters.
+    #LOC_RestockPlus_restock-fuel-tank-0625-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
+    #LOC_RestockPlus_restock-fuel-tank-0625-3_title = Oscar-C Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-0625-3_description = A doubled Oscar B with alphabetically incremented suffix.
+    #LOC_RestockPlus_restock-fuel-tank-0625-3_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
+    #LOC_RestockPlus_restock-fuel-tank-0625-5_title = Oscar-A Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-0625-5_description = A prequel to the Oscar B, this tank holds a fairly small amount of fuel.
+    #LOC_RestockPlus_restock-fuel-tank-0625-5_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
+
+    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title = Oscar-O Hemispherical Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_description = A tiny half-sphere of gas to get you halfway to where you need to go.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
+
+    // 1.25m
+    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title = FL-T50-R Hemispherical Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_description = A 1.25m half-sphere that stores liquid fuel and oxidizer.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
+
+    // 1.875m
+    #LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_title = FL-R4 RCS Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_description = A medium monopropellant tank made of four small capsules. Do not over or underpressurize - keep it juuuust right.
+    #LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_tags = restock fuel fueltank mono propellant rcs
+
+    #LOC_RestockPlus_restock-fuel-tank-1875-1_title = FL-X1800 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-1_description = The FL-X series is the size-wise successor to the FL-T series and gets you more fuel without running into Rockomax patent territory.
+    #LOC_RestockPlus_restock-fuel-tank-1875-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-2_title = FL-X900 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-2_description = A half-size tank like this one can carry a good amount of rocket fuel and do it while looking real good.
+    #LOC_RestockPlus_restock-fuel-tank-1875-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-3_title = FL-X440 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-3_description = Small but still impressive, the kerosene fumes emitted by this tank add an immediate ambiance to any storerooms used for holding rocket fuel tanks. Please ensure such rooms are well ventilated.
+    #LOC_RestockPlus_restock-fuel-tank-1875-3_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-4_title = FL-X220 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-4_description = Diminutively sized, this tank nevertheless can provide sufficient impulse for a well-conceived or spur of the moment burn.
+    #LOC_RestockPlus_restock-fuel-tank-1875-4_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_title = FL-S1200 Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_description = This interestingly shaped fuel tank is conical and not cylindrical. It even includes small separation motors in case you want to use it as a booster, because you probably could.
+    #LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank soyuz
+
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title = FL-XA600 Fuel Tank Adapter
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_description = Sometimes you need a few different sizes in your rocket and that's ok. If you want to blend them smoothly, you need fuel, and your two sizes are 1.875m and 1.25m, this part is your ticket.
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title = FL-XA160 Fuel Tank Adapter
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_description = Much like its larger brother, this part steps from 1.25m to 1.875m and is chock full of craft-grade rocket fuel.
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FL-XA160-S Fuel Tank Adapter
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_description = An extra small cross section is no problem from this fully fueled adapter, which gracefully adapts from 1.875m to 0.625m.
+    #LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title = FL-XA1200 Fuel Tank Adapter
+    #LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_description = A large fully fuelled adapter to step down from the large 2.5m size to a modest 1.875m size.
+    #LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+
+    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title = FL-TX220-R Hemispherical Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_description = Hey, it's a round, hemispherical tank carrying rocket fuel - also available in several colours.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
+
+    // 2.5m
+    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title = Rockomax X-200-4R Hemispherical Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_description = This fuel tank is half a sphere. It should not be used as a pool, unlike other Rockomax products
+    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
+
+    // 3.75m
+    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title = FL-S1 RCS Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_description = A very large monopropellant tank that stores a considerable quantity of fuel in its 6 spherical pressure vessels.
+    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_tags = restock fuel fueltank mono propellant rcs
+
+    #LOC_RestockPlus_restock-fuel-tank-375-4_title = Kerbodyne S3-1800 Tank
+    #LOC_RestockPlus_restock-fuel-tank-375-4_description = A special compact tank filling a particular hole in Kerbodyne's heavy part lineup. Now you can make Kerosene pancakes!
+    #LOC_RestockPlus_restock-fuel-tank-375-4_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank s3 1800
+
+    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title = Kerbodyne S3-900R Hemispherical Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_description = Compared to the S3-1800, the S3-900R is rounder, more spherical, and importantly, more cut in two.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
+
+    // 5m
+    #LOC_RestockPlus_restock-fuel-tank-5-1_title = Kerbodyne SIV-512K Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-5-1_description = The initial run of SIV Liquid Fuel Tanks were manufactured when the Lead Engineer sent the schematics to fabrication at a mis-labeled scale. The results came back much bigger than the KSC employees expected and thus a new range of super-sized rockets was born. One of Kerbodyne's biggest ever tanks, its a monster.
+    #LOC_RestockPlus_restock-fuel-tank-5-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-5-2_title = Kerbodyne SIV-256K Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-5-2_description = The initial run of SIV Liquid Fuel Tanks were manufactured when the Lead Engineer sent the schematics to fabrication at a mis-labeled scale. The results came back much bigger than the KSC employees expected and thus a new range of super-sized rockets was born. This large sized tank will keep you running for a long while.
+    #LOC_RestockPlus_restock-fuel-tank-5-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-5-3_title = Kerbodyne SIV-128K Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-5-3_description = The initial run of SIV Liquid Fuel Tanks were manufactured when the Lead Engineer sent the schematics to fabrication at a mis-labeled scale. The results came back much bigger than the KSC employees expected and thus a new range of super-sized rockets was born. This medium sized tank can get you places.
+    #LOC_RestockPlus_restock-fuel-tank-5-3_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+    #LOC_RestockPlus_restock-fuel-tank-5-4_title = Kerbodyne SIV-64K Liquid Fuel Tank
+    #LOC_RestockPlus_restock-fuel-tank-5-4_description = The initial run of SIV Liquid Fuel Tanks were manufactured when the Lead Engineer sent the schematics to fabrication at a mis-labeled scale. The results came back much bigger than the KSC employees expected and thus a new range of super-sized rockets was born. This smaller tank still holds a lot of juice.
+    #LOC_RestockPlus_restock-fuel-tank-5-4_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
+
+    #LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title = Kerbodyne SAIV Liquid Fuel Tank Adapter
+    #LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_description = Following Kerbodyne's effort to manufacture enormously sized tanks an adapter was required to retrofit them back to a more commonly utilized size.
+    #LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank adapter
+    #LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_title = Kerbodyne SIV Fuelled Engine Adapter
+    #LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_description = A Kerbodyne Design Engineer recently heard of the word 'Quincunx' and upon looking up its definition realized that it would be the perfect shape to house five engines underneath the huge SIV range of Liquid Fuel Tanks.
+    #LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_tags = restock rocket fuel liquid oxidizer propellant fueltank ?lfo tank saturn enormous massive gigantic giant cross feed 5.0
+
+    // THERMAL
+    // =======
+
+    // 1.875m
+    #LOC_RestockPlus_restock-heatshield-1875-1_title = Heat Shield (1.875m)
+    #LOC_RestockPlus_restock-heatshield-1875-1_description = A specially sized thermal shield for medium sized rockets. Curiously, has a passageway for a hatch in there - almost looks like it was made by moles.
+    #LOC_RestockPlus_restock-heatshield-1875-1_tags = ablat drag entry insulate protect re- rocket therm restock
+
+    // COMMAND
+    // ========
+
+    // 0.625m
+    #LOC_RestockPlus_restock-drone-core-0625-1_title = RC-XS1 Remote Guidance Unit
+    #LOC_RestockPlus_restock-drone-core-0625-1_description = The smallest remote guidance unit may be tiny, but it'll get you to where you need to go eventually.
+    #LOC_RestockPlus_restock-drone-core-0625-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock remote rgu
+
+    // 1.25m
+    #LOC_RestockPlus_restock-pod-sphere-1_title = SP-1 'Clementine' Reentry Module
+    #LOC_RestockPlus_restock-pod-sphere-1_description = When faced with the challenge of keeping the heat shield facing forward during reentry, one engineer suggested making the whole thing a heat shield, and this spherical command module was born.
+    #LOC_RestockPlus_restock-pod-sphere-1_tags = 1 capsule control ?eva fly ?iva pilot rocket space history historical pod vostok restock hamster ball
+
+    #LOC_RestockPlus_restock-pod-sphere-2_title = SP-2 'Tangerine' Reentry Module
+    #LOC_RestockPlus_restock-pod-sphere-2_description = We removed some "unnecessary" equipment from the SP-1 Reentry Module to make room for a second seat. This decision had made the design department very unpopular with the astronauts.
+    #LOC_RestockPlus_restock-pod-sphere-2_tags = 2 capsule control ?eva fly ?iva pilot rocket space history historical pod voskhod restock
+
+    #LOC_RestockPlus_restock-pod-sphere-3_title = SP-3 'Mandarin' Reentry Module
+    #LOC_RestockPlus_restock-pod-sphere-3_description = We hired a shady interior decorator to fit three seats into the same space as one. The occupants are no longer able to move their arms to access the controls, but at least they'll probably survive.
+    #LOC_RestockPlus_restock-pod-sphere-3_tags = 3 capsule control ?eva fly ?iva pilot rocket space history historical pod voskhod restock sardines
+
+    // 1.875m
+    #LOC_RestockPlus_restock-mk2-pod_title = Mk2 'Acorn' Command Pod
+    #LOC_RestockPlus_restock-mk2-pod_description = The immediate successor to the Mk1 command pod, the Mk2 seats two kerbals instead of one, and has handy forward-facing windows to enable docking.
+    #LOC_RestockPlus_restock-mk2-pod_tags = capsule cmg control ?eva fly gyro ?iva moment pilot space stab steer torque gemini restock
+
+    #LOC_RestockPlus_restock-drone-core-1875-1_title = RC-M001 Remote Guidance Unit
+    #LOC_RestockPlus_restock-drone-core-1875-1_description = This unit has a low sentience quotient, so you probably won't need to be careful about leaving the pod bay doors open all the time.
+    #LOC_RestockPlus_restock-drone-core-1875-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock remote rgu
+
+    // 3.75m
+    #LOC_RestockPlus_restock-drone-core-375-1_title = RC-XL001 Remote Guidance Unit
+    #LOC_RestockPlus_restock-drone-core-375-1_description = The massive XL RGU system designed by Kerbodyne and built by STEADLER is a triumph of aerospace engineering and contains important features such as the large empty void in the center, which can be filled with anything you like. Unlike other stack RGUs, it contains powerful reaction wheels so doubles as a guidance unit.
+    #LOC_RestockPlus_restock-drone-core-375-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock xl001 remote rgu
+
+    // COUPLING
+    // ========
+
+    // Radial
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_title = TT-14 Radial Decoupler
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_description = It's an extra small decoupler for very small separation events.
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_tags = restock break decouple separat split stag
+
+    // 0.625m
+    #LOC_RestockPlus_restock-claw-625-1_title = Compact Grabbing Unit Jr.
+    #LOC_RestockPlus_restock-claw-625-1_description = A smaller claw for grappling smaller things. Unfortunately, it does not pivot.
+    #LOC_RestockPlus_restock-claw-625-1_tags = restock a.r.m arm asteroid capture clam claw connect dock fasten grab join klaw nasa 625
+
+    #LOC_RestockPlus_restock-airlock-inflatable-625-1_title = AL-1 'Lychee' Inflatable Docking Airlock
+    #LOC_RestockPlus_restock-airlock-inflatable-625-1_description = Being able to traverse between the inside and outside of things has been a recurring challenge for Kerbals for millennia. This airlock solves that problem in a sleek inflatable package, and includes a docking ring compatible with the Clamp-O-Tron jr. to boot!
+    #LOC_RestockPlus_restock-airlock-inflatable-625-1_tags = restock berth capture connect couple dock fasten join moor shield socket inflate airlock Leonov Voskhod
+
+    // 1.25m
+    #LOC_RestockPlus_restock-engineplate-125-1_title = EP-12 Engine Plate
+    #LOC_RestockPlus_restock-engineplate-125-1_description = A small plate for holding one or more engines. Includes optional boattail to protect first stage engines, or several lengths of shroud. Includes a decoupler for use with upper stages.
+    #LOC_RestockPlus_restock-engineplate-125-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 125 1.25 Electron
+
+    // 1.875m
+    #LOC_RestockPlus_restock-decoupler-1875-1_title = TD-18 Decoupler
+    #LOC_RestockPlus_restock-decoupler-1875-1_description = This stack decoupler is a medium sized tool for splitting rockets.
+    #LOC_RestockPlus_restock-decoupler-1875-1_tags = restock break decouple explo separat split
+
+    #LOC_RestockPlus_restock-decoupler-1875-truss-1_title = TD-18T Truss Decoupler
+    #LOC_RestockPlus_restock-decoupler-1875-truss-1_description = This is a decoupler with hollow bits - suitable for hot-staging engines when you split your rocket in twain.
+    #LOC_RestockPlus_restock-decoupler-1875-truss-1_tags = restock break decouple explo kerbodyne separat split
+
+    #LOC_RestockPlus_restock-separator-1875-1_title = TS-18 Separator
+    #LOC_RestockPlus_restock-separator-1875-1_description = This stack separator is a medium sized separator, much like the other separators. Unlike Decouplers, Separators will eject anything connected to themselves. This is good, as it removes the need to worry about which side needs to be pointed away from face. Try to not look at it too much though.
+    #LOC_RestockPlus_restock-separator-1875-1_tags = restock break decouple separat split stag
+
+    #LOC_RestockPlus_restock-engineplate-1875-1_title = EP-18 Engine Plate
+    #LOC_RestockPlus_restock-engineplate-1875-1_description = A medium sized plate for holding one or more engines, with included decoupler for anything attached below it.
+    #LOC_RestockPlus_restock-engineplate-1875-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 1875 1.875 Titan
+
+    // 2.5m
+    #LOC_RestockPlus_restock-engineplate-25-1_title = EP-25 Engine Plate
+    #LOC_RestockPlus_restock-engineplate-25-1_description = A large plate for holding one or more engines, with included decoupler for anything attached below it.
+    #LOC_RestockPlus_restock-engineplate-25-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 25 2.5 Falcon
+
+    // 3.75m
+    #LOC_RestockPlus_restock-docking-375-1_title = Clamp-O-Tron Docking Port 'Grande'
+    #LOC_RestockPlus_restock-docking-375-1_description = When the thrill of docking enormous objects in space disappears, one must logically proceed to humongous objects. This even larger docking port is the result of 6 months of R&D to define the precise meaning of the word 'humongous'.
+    #LOC_RestockPlus_restock-docking-375-1_tags = restock berth capture connect couple dock fasten join moor socket clamp grande
+
+    #LOC_RestockPlus_restock-engineplate-375-1_title = EP-37 Engine Plate
+    #LOC_RestockPlus_restock-engineplate-375-1_description = A gigantic plate for holding one or more engines, with included decoupler for anything attached below it.
+    #LOC_RestockPlus_restock-engineplate-375-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 375 3.75 Zenit
+
+    // 5m
+    #LOC_RestockPlus_restock-decoupler-5-1_title = TD-50 Decoupler
+    #LOC_RestockPlus_restock-decoupler-5-1_description = An enormous decoupler that acts as a specialized tool for ripping your rocket stack apart.
+    #LOC_RestockPlus_restock-decoupler-5-1_tags = restock break decouple explo separat split
+
+    #LOC_RestockPlus_restock-separator-5-1_title = TS-50 Separator
+    #LOC_RestockPlus_restock-separator-5-1_description = This stack separator is an enormous separator that has enough ejection power to inject a decent amount of impulse into objects being disconnected on either side with great gusto. Do not be near on EVA whilst staging!
+    #LOC_RestockPlus_restock-separator-5-1_tags = restock break decouple separat split stag
+
+    #LOC_RestockPlus_restock-engineplate-5-1_title = EP-50 Engine Plate
+    #LOC_RestockPlus_restock-engineplate-5-1_description = An enormous plate for holding one or more engines, with included decoupler for anything attached below it. Upgraded version currently pending government approval.
+    #LOC_RestockPlus_restock-engineplate-5-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 5 Ares V
+
+    // AERO
+    // ====
+
+    // 0.625m
+    #LOC_RestockPlus_restock-nosecone-0625-1_title = Miniature Rocket Nose
+    #LOC_RestockPlus_restock-nosecone-0625-1_description = A slightly more rocket-appropriate tiny nosecone, available in white and shiny metal finishes.
+    #LOC_RestockPlus_restock-nosecone-0625-1_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose
+
+    // 1.875m
+    #LOC_RestockPlus_restock-nosecone-1875-1_title = Protective Rocket Nose Mk18
+    #LOC_RestockPlus_restock-nosecone-1875-1_description = Discontinued due to component shortages. For capping off those medium size boosters, you can't beat the Mark 18, unless you're the Mark 19.
+    #LOC_RestockPlus_restock-nosecone-1875-1_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose mk18
+
+    #LOC_RestockPlus_restock-nosecone-1875-2_title = Protective Rocket Nose Mk18
+    #LOC_RestockPlus_restock-nosecone-1875-2_description = For capping off those medium size boosters, you can't beat the Mark 18, unless you're the Mark 19.
+    #LOC_RestockPlus_restock-nosecone-1875-2_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose mk18
+
+    // 3.75m
+    #LOC_RestockPlus_restock-nosecone-375-1_title = Kerbodyne S3-3600 Nosecone
+    #LOC_RestockPlus_restock-nosecone-375-1_description = A specialized and monstrous nosecone with revolutionary fuel-containing capabilities.
+    #LOC_RestockPlus_restock-nosecone-375-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank s3 3600 nose cone
+
+    // 5m
+    #LOC_RestockPlus_restock-nosecone-5-1_title = Kerbodyne SIV Nosecone
+    #LOC_RestockPlus_restock-nosecone-5-1_description = A very sizeable nosecone for very sizeable rockets.
+    #LOC_RestockPlus_restock-nosecone-5-1_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose
+
+    // STRUCTURAL
+    // ==========
+
+    // 0.625m
+    #LOC_RestockPlus_restock-node-625-1_title = BZ-26 Radial Attachment Point Jr.
+    #LOC_RestockPlus_restock-node-625-1_description = After the surprise success of the BZ-52, the Maxo Construction Toys engineering team came out of hiding to reveal the new pocket model.
+    #LOC_RestockPlus_restock-node-625-1_tags = affix anchor mount secure restock
+
+    // 1.25m
+    #LOC_RestockPlus_restock-structural-tube-125-1_title = TB-125 Structural Tube
+    #LOC_RestockPlus_restock-structural-tube-125-1_description = A small tube, full of wonderous things. Available in many lengths and even finishes!
+    #LOC_RestockPlus_restock-structural-tube-125-1_tags = restock hollow pipe tube support structur build construct struct
+
+    // 1.875m
+    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_title = FL-XA30 Adapter
+    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_description = Connect two tubes of different size classes together! Oh the kerbality!
+    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_tags = connect frame scaffold adapt structur restock adtp
+    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_title = FL-XA15 Adapter
+    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_description = Effectively connects small sized 1.25m tubes to larger medium 1.875m tubes.
+    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_tags = connect frame scaffold adapt structur restock adtp
+
+    #LOC_RestockPlus_restock-structural-tube-1875-1_title = TB-1875 Structural Tube
+    #LOC_RestockPlus_restock-structural-tube-1875-1_description = A medium tube for the cylindrically inclined. Available in many lengths and even finishes!
+    #LOC_RestockPlus_restock-structural-tube-1875-1_tags = restock hollow pipe tube support structur build construct struct
+
+    #LOC_RestockPlus_restock-node-1875-1_title = BZ-78 Radial Attachment Point
+    #LOC_RestockPlus_restock-node-1875-1_description = Development of a 1.875m docking port never received adequate funding, so management decided to cut their losses and release it unfinished as an attachment point.
+    #LOC_RestockPlus_restock-node-1875-1_tags= affix anchor mount secure restock
+
+    // 2.5m
+    #LOC_RestockPlus_restock-structural-tube-25-1_title = TB-25 Structural Tube
+    #LOC_RestockPlus_restock-structural-tube-25-1_description = A large tube for those that wish to store things. Available in many lengths and even finishes!
+    #LOC_RestockPlus_restock-structural-tube-25-1_tags = restock hollow pipe tube support structur build construct struct
+
+    // 3.75m
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_title = Kerbodyne ADTP-2-3A
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the other Kerbodyne adapter, which allows the storage of spacecraft components in its core.
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_tags = connect frame scaffold adapt structur strut truss hollow skel carg restock adtp
+
+    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_title = Kerbodyne SKLE-2-3
+    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_description = A structural adapter for upper stages.
+    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_tags = connect frame scaffold adapt structur strut truss eus hollow skel restock skle
+
+    #LOC_RestockPlus_restock-structural-tube-375-1_title = TB-375 Structural Tube
+    #LOC_RestockPlus_restock-structural-tube-375-1_description = A larger tube for those who wish to store things. Available in many lengths and even finishes!
+    #LOC_RestockPlus_restock-structural-tube-375-1_tags = restock hollow pipe tube support structur build construct struct
+
+    // 5m
+    #LOC_RestockPlus_restock-structural-tube-5-1_title = TB-500 Structural Tube
+    #LOC_RestockPlus_restock-structural-tube-5-1_description = Truly, the largest tube we have. Available in many lengths and even finishes!
+    #LOC_RestockPlus_restock-structural-tube-5-1_tags = restock hollow pipe tube support structur build construct struct
+
+    // Truss
+    #LOC_RestockPlus_restock-truss-3_title = Modular Girder Segment XXL
+    #LOC_RestockPlus_restock-truss-3_description = Compete directly with other space programs in girder size contests with this new Modular Girder product.
+    #LOC_RestockPlus_restock-truss-3_tags = connect frame scaffold structur strut truss restock
+
+    #LOC_RestockPlus_restock-truss-adapter-0625-1_title = Modular Girder Small Adapter
+    #LOC_RestockPlus_restock-truss-adapter-0625-1_description = Generally, marketing anticipates that by providing a means for small stacks to attach cleanly to standard Modular Girders, demand for the latter will skyrocket.
+    #LOC_RestockPlus_restock-truss-adapter-0625-1_tags = connect frame scaffold structur strut truss restock adapt
+
+    #LOC_RestockPlus_restock-truss-hub-1_title = Modular Girder Hub
+    #LOC_RestockPlus_restock-truss-hub-1_description = Connect many modular girder segments together in perpendicular orientations with this new product.
+    #LOC_RestockPlus_restock-truss-hub-1_tags = connect frame scaffold structur strut truss restock center central hub nexus
+
+    // ELECTRICAL
+    // ==========
+
+    // Radial
+    #LOC_RestockPlus_restock-apu-radial-1_title = NH-24 Monopropellant APU
+    #LOC_RestockPlus_restock-apu-radial-1_description = After playing with a children's pinwheel toy and asking themselves "how could this become more awesome", one engineer tried pointing a small rocket engine at it. The engineering team immediately got to work using it to generate electricity, and the Monopropellant APU was born
+    #LOC_RestockPlus_restock-apu-radial-1_tags = APU backup turbine array bank charge convert e/c elect energ pack power volt watt
+
+    #LOC_RestockPlus_restock-apu_name = APU turbine
+    #LOC_RestockPlus_restock-apu_start = Start turbine
+    #LOC_RestockPlus_restock-apu_stop = Stop turbine
+    #LOC_RestockPlus_restock-apu_toggle = Toggle turbine
+
+    // 1.875m
+    #LOC_RestockPlus_restock-battery-1875-1_title = Z-2.5K Rechargeable Battery Bank
+    #LOC_RestockPlus_restock-battery-1875-1_description = Medium battery pack for medium battery applications.
+    #LOC_RestockPlus_restock-battery-1875-1_tags = capacitor cell charge e/c elect pack power volt watt restock battery
+
+    // 3.75m
+    #LOC_RestockPlus_restock-battery-375-1_title = Z-10K Rechargeable Battery Bank
+    #LOC_RestockPlus_restock-battery-375-1_description = A gigantic battery pack for the largest rockets. Special on this model, Zaltronic includes mishap insurance - the first time your drop your battery, it will be replaced for free! However, the battery is not user-serviceable.
+    #LOC_RestockPlus_restock-battery-375-1_tags = capacitor cell charge e/c elect pack power volt watt restock 10k battery
+
+    // PAYLOAD
+    // =======
+
+    // 0.625m
+    #LOC_RestockPlus_restock-fairing-base-0625-1_title = AE-FF0 Airstream Protective Shell (0.625m)
+    #LOC_RestockPlus_restock-fairing-base-0625-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! This protective shell is an even tinier size available from FLOOYD.
+    #LOC_RestockPlus_restock-fairing-base-0625-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 625
+
+    // 1.25m
+
+    #LOC_RestockPlus_restock-service-module-125-625-1_title = Service Module (1.25m)
+    #LOC_RestockPlus_restock-service-module-125-625-1_description = A small conical service module, for storing parachutes, instruments, and other small devices. Includes an optional docking tunnel.
+    #LOC_RestockPlus_restock-service-module-125-625-1_tags = restock bus contain hollow protect (stor cone tunnel
+
+    // 1.875m
+    #LOC_RestockPlus_restock-fairing-base-1875-1_title = AE-FF1-L Airstream Protective Shell (1.875m)
+    #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, this protective shell has recently become available.
+    #LOC_RestockPlus_restock-fairing-base-1875-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 875
+
+    #LOC_RestockPlus_restock-service-bay-1875-1_title = Service Bay (1.875m)
+    #LOC_RestockPlus_restock-service-bay-1875-1_description = A medium sized heat resistant service bay, ideal for protecting delicate instruments or stowing small service components such as RCS tanks, batteries, etc.
+    #LOC_RestockPlus_restock-service-bay-1875-1_tags = restock bus contain heat hollow protect (stor therm
+
+    #LOC_RestockPlus_restock-service-module-1875-1_title = Service Module (1.875m)
+    #LOC_RestockPlus_restock-service-module-1875-1_description = A medium sized service module, for storing fuel tanks, batteries, fuel cells, etc.
+    #LOC_RestockPlus_restock-service-module-1875-1_tags = restock bus contain hollow protect (stor Gemini
+
+    // 5m
+    #LOC_RestockPlus_restock-fairing-base-5-1_title = AE-FF4 Airstream Protective Shell (5m)
+    #LOC_RestockPlus_restock-fairing-base-5-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel!
+    #LOC_RestockPlus_restock-fairing-base-5-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport
+
+    // SCIENCE
+    // =======
+
+    // Radial
+    #LOC_RestockPlus_restock-materialbay-radial-1_title = SC-9001R Radial Science Jr.
+    #LOC_RestockPlus_restock-materialbay-radial-1_description = The radial variant of the Science Jr. has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
+    #LOC_RestockPlus_restock-materialbay-radial-1_tags = bay experiment lab material research radial sandwich kracken kraken restock
+
+    // 0.625m
+    #LOC_RestockPlus_restock-goocanister-625-1_title = Mystery Goo™ Inline Containment Unit
+    #LOC_RestockPlus_restock-goocanister-625-1_description = After an unfortunate accident where a technician attempted to stack delicate machinery on the classic Mystery Goo™ canister, FLOOYD Dynamics Labs saw a market opportunity for a version with a flat top and bottom.
+    #LOC_RestockPlus_restock-goocanister-625-1_tags = experiment research science 0.625 restock mystery goo inline
+
+    #LOC_RestockPlus_restock-sciencebox-inline-1_title = Experiment Return Unit
+    #LOC_RestockPlus_restock-sciencebox-inline-1_description = Since science experiments kept getting destroyed before being recovered, our kerbal engineers designed the Experiment Return Unit in a conical shape to better survive the rigors of atmospheric reentry. Heat shield sold separately.
+    #LOC_RestockPlus_restock-sciencebox-inline-1_tags = experiment research science recovery reentry restock .625 1.25 inline
+
+    // COMMUNICATIONS
+    // ==============
+
+    #LOC_RestockPlus_restock-relay-radial-2_title = HG-20 High Gain Antenna
+    #LOC_RestockPlus_restock-relay-radial-2_description = A longer range version of the HG-5 that can handle either direct communications or short range relays, using 4 different dishes.
+    #LOC_RestockPlus_restock-relay-radial-2_tags = relay antenna radial science transmit data Apollo restock hg 20
+
+    #LOC_RestockPlus_restock-antenna-stack-2_title = Communotron DTS-J1
+    #LOC_RestockPlus_restock-antenna-stack-2_description = A fixed mount version of the popular DTS-M1 antenna. this version is a more traditional dish, giving it better efficiency at the expense of higher mass.
+    #LOC_RestockPlus_restock-antenna-stack-2_tags = antenna radial transmit data dish Juno restock communotron dts j1
+
+    #LOC_RestockPlus_restock-antenna-stack-3_title = Communotron HG-61
+    #LOC_RestockPlus_restock-antenna-stack-3_description = After developing the venerable HG-55, one of our marketing people came up with the idea of a budget version for small probes. The HG-61 removes the fancy extending arm, while still providing the same great communication range of its predecessor, making it perfect for building deep space probes on a budget.
+    #LOC_RestockPlus_restock-antenna-stack-3_tags = antenna radial transmit data dish Galileo TDRS restock communotron hg 61
+
+    // LADDERS
+    // =======
+
+    #LOC_RestockPlus_restock-ladder-static-2_title = Pegasus II Mobility Enhancer
+    #LOC_RestockPlus_restock-ladder-static-2_description = A logical extension of the Pegasus I, the Pegasus II however does not extend but is twice as long, allowing for longer, more dramatic climbing sequences.
+    #LOC_RestockPlus_restock-ladder-static-2_tags = ascend climb descend ladder rung safe step restock
+
+    #LOC_RestockPlus_restock-ladder-static-3_title = Pegasus III Mobility Enhancer
+    #LOC_RestockPlus_restock-ladder-static-3_description = A much needed enhancement to a mobility enhancement. It is very long.
+    #LOC_RestockPlus_restock-ladder-static-3_tags = ascend climb descend ladder rung safe step restock
+
+    // RESOURCE
+    // ========
+
+    // 1.875m
+    #LOC_RestockPlus_restock-oretank-1875-1_title = Medium Holding Tank
+    #LOC_RestockPlus_restock-oretank-1875-1_description = A medium tank that can be used for storing raw materials. Warranty void if used to store snacks.
+    #LOC_RestockPlus_restock-oretank-1875-1_tags = black isru mine )mining (ore resource store restock
+
+    // 3.75m
+    #LOC_RestockPlus_restock-oretank-375-1_title = Jumbo Holding Tank
+    #LOC_RestockPlus_restock-oretank-375-1_description = A very large tank that can be used for storing raw materials. The manufacturer denies any claims that it has been re-purposed from a local farm
+    #LOC_RestockPlus_restock-oretank-375-1_tags = black isru mine )mining (ore resource store restock
+
+    // GROUND
+    // ======
+
+    #LOC_RestockPlus_restock-wheel-1-T_title = Rovemax Model S2-T
+    #LOC_RestockPlus_restock-wheel-1-T_description = A modified rover wheel that is rotated 90°, ideal for tricycles or other unusually shaped vehicles.
+    #LOC_RestockPlus_restock-wheel-1-T_tags = )car drive ground roll rover wheel tricycle restock
+
+    #LOC_RestockPlus_restock-wheel-4_title = Rovemax Model M0
+    #LOC_RestockPlus_restock-wheel-4_description = A smaller version of the popular Rovemax wheel with an integrated folding function, allowing it to be stowed for transportation.
+    #LOC_RestockPlus_restock-wheel-4_tags = )car drive ground roll rover wheel fold LRV restock
+  }
+}

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/ja.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/ja.cfg
@@ -6,7 +6,7 @@
 
 Localization
 {
-  en-us
+  ja
   {
 
     // AGENCIES
@@ -36,17 +36,17 @@ Localization
     // ENGINES
     // =======
     // 3.75m
-    #LOC_RestockPlus_restock-engine-corgi_title = KR-10A 'Corgi' Liquid Fuel Engine Cluster
-    #LOC_RestockPlus_restock-engine-corgi_description = Kerbodyne engineers have discovered that clustering can be an effective solution when you need more thrust, and don't want to add more boosters. This upper stage engine is very efficient as it takes advantage of a set of four lovingly handcrafted engines.
+    #LOC_RestockPlus_restock-engine-corgi_title = KR-10A 'コーギー' 液体燃料エンジンクラスタ
+    #LOC_RestockPlus_restock-engine-corgi_description = カーボダイン社の技術者は、ブースターを増やすことなく大きな推力を得るにはクラスタリングが効果的な解決策だと発見しました。愛情込めて手作りされた4基のエンジンを利用するこの上段エンジンは非常に効率的です。
     #LOC_RestockPlus_restock-engine-corgi_tags = orbit vac upper propuls sls rl10 eus restock kr 10a corgi
 
     // 2.5m
-    #LOC_RestockPlus_restock-engine-boar_title = KR-1 'Boar' Liquid Fuel Engine
-    #LOC_RestockPlus_restock-engine-boar_description = The single Boar is slightly more efficient than its dual counterpart, and provides, logically, half the thrust. Due to a less integrated set of mounting points, there is a slight decrease in raw thrust-to-weight ratio.
+    #LOC_RestockPlus_restock-engine-boar_title = KR-1 'ボア' 液体燃料エンジン
+    #LOC_RestockPlus_restock-engine-boar_description = シングルボアはツインボアよりもわずかに効率が良く、論理的には半分の推力を提供します。マウント部の統合が進んでいないので、推力対重量比はわずかに減少します。
     #LOC_RestockPlus_restock-engine-boar_tags = ascent main propuls lower sls dynetics f1b restock kr1 boar
 
-    #LOC_RestockPlus_restock-engine-cherenkov_title = LV-N410 'Cherenkov' Atomic Rocket Motor
-    #LOC_RestockPlus_restock-engine-cherenkov_description = By popular demand, Rockomax has brought a powerful large nuclear engine to market. Like its smaller cousin the Nerv, it runs on only Liquid Fuel. As a result of a large development budget, gimballing mechanisms have been installed on the turbopump exhaust ducts, allowing limited vectored thrust abilities.
+    #LOC_RestockPlus_restock-engine-cherenkov_title = LV-N410 'チェレンコフ' 原子力ロケットモーター
+    #LOC_RestockPlus_restock-engine-cherenkov_description = ご要望の多かった、ロックマックス社の強力な大型原子力エンジンが発売されました。小型のナーブと同様に液体燃料で作動します。多額の開発費を投入した結果、ターボポンプの排気ダクトにジンバル機構が搭載され、限定的な推力偏向が可能になりました。
     #LOC_RestockPlus_restock-engine-cherenkov_tags = active atom efficient engine inter liquid (cherenkov nuclear nuke orbit propuls radio reactor vacuum restock
 
     // 1.875m
@@ -75,17 +75,17 @@ Localization
     #LOC_RestockPlus_restock-engine-galleon_tags = ascent main propuls lower paperclip restock ur1 (galleon f1 saturn
 
     // 1.25m
-    #LOC_RestockPlus_restock-engine-pug_title = LV-303 'Pug' Liquid Fuel Engine
-    #LOC_RestockPlus_restock-engine-pug_description = What a cute little engine! All dressed up and ready for Baby's First Upper Stage.
+    #LOC_RestockPlus_restock-engine-pug_title = LV-303 'パグ' 液体燃料エンジン
+    #LOC_RestockPlus_restock-engine-pug_description = なんてかわいいエンジンなんでしょう！赤ちゃんの最初の上段ステージのために、ドレスアップして準備万端です。
     #LOC_RestockPlus_restock-engine-pug_tags = orbit vac upper propuls restock 303 pug
 
-    #LOC_RestockPlus_restock-engine-valiant_title = LV-T15 'Valiant' Liquid Fuel Engine
-    #LOC_RestockPlus_restock-engine-valiant_description = The first (well, the first that didn't regularly explode) model in the famed LV series of engines. Just enough to get you flying, and it even offers such startling amenities as "throttle" and "gimbal".
+    #LOC_RestockPlus_restock-engine-valiant_title = LV-T15 'ヴァリアント' 液体燃料エンジン
+    #LOC_RestockPlus_restock-engine-valiant_description = 有名なLVシリーズのエンジンの最初の（えー、定期的に爆発しなくなった最初の）モデルです。飛行に十分な性能をもつだけでなく、「スロットル」や「ジンバル」など、驚きの機能を搭載しています。
     #LOC_RestockPlus_restock-engine-valiant_tags = ascent main propuls lower sls restock t15 valiant
 
     // 0.625m
-    #LOC_RestockPlus_restock-engine-torch_title = Mk-1H 'Torch' Liquid Fuel Engine
-    #LOC_RestockPlus_restock-engine-torch_description = When your booster is small and needs a real kick, the Torch's ability to produce high temperature gases as a prodigious rate will do you well.
+    #LOC_RestockPlus_restock-engine-torch_title = Mk-1H 'トーチ' 液体燃料エンジン
+    #LOC_RestockPlus_restock-engine-torch_description = 小さなブースターで本格的なキックが必要な場合、高温のガスを驚異の速度で発生させるトーチの能力は、あなたに良い結果をもたらすでしょう。
     #LOC_RestockPlus_restock-engine-torch_tags = ascent main propuls lower titan restock mk1h torch
 
     #LOC_RestockPlus_restock-engine-srb-mallet_title = RT-1 'Mallet' Solid Rocket Booster
@@ -96,8 +96,8 @@ Localization
     #LOC_RestockPlus_restock-engine-srb-striker_description = Discontinued due to component shortages. Extending the Mallet with additional segments can provide more boom than your integration team knows what to do with!
     #LOC_RestockPlus_restock-engine-srb-striker_tags = a moar (more motor rocket srb restock striker
 
-    #LOC_RestockPlus_restock-engine-les-2_title = Launch Escape System Jr.
-    #LOC_RestockPlus_restock-engine-les-2_description = A smaller solid rocket tower for yeeting crew away from certain death.
+    #LOC_RestockPlus_restock-engine-les-2_title = 打ち上げ脱出システム Jr.
+    #LOC_RestockPlus_restock-engine-les-2_description = 乗組員を恒久的な死から遠ざけるための小型の固体ロケットタワーです。
     #LOC_RestockPlus_restock-engine-les-2_tags = abort booster emergency explo ?les l.e.s malfunc ?rud safe solid surviv restock junior 625
 
     // Radial
@@ -109,21 +109,21 @@ Localization
     // =======
 
     // Reaction wheels
-    #LOC_RestockPlus_restock-reactionwheel-radial-1_title = Small Radial Gyroscope
-    #LOC_RestockPlus_restock-reactionwheel-radial-1_description = Steadler's small radial gyroscope provides a small amount of torque but with greater power efficiency, allowing even large stations to maintain attitude with minimal power. We're still not entirely sure how gyroscopes work, but this one allows torque on all three axes.
+    #LOC_RestockPlus_restock-reactionwheel-radial-1_title = 小型ラジアルジャイロスコープ
+    #LOC_RestockPlus_restock-reactionwheel-radial-1_description = ステッドラーの小型ラジアルジャイロスコープは、小トルクですが電力効率が高く、大型ステーションでも最小限の電力で姿勢を維持することが可能です。仕組みはまだ完全には解明されていませんが、このジャイロスコープは3軸すべてでトルクを発生させることができます。
     #LOC_RestockPlus_restock-reactionwheel-radial-1_tags = cmg command control fly gyro moment react stab steer torque magic_spinny_thing restock
 
-    #LOC_RestockPlus_restock-reactionwheel-1875-1_title = Medium Reaction Wheel Assembly
-    #LOC_RestockPlus_restock-reactionwheel-1875-1_description = We purchased several of these gyroscope modules to ensure we could accurately control our medium sized rockets in all phases of flight.
+    #LOC_RestockPlus_restock-reactionwheel-1875-1_title = 中型リアクションホイールアセンブリ
+    #LOC_RestockPlus_restock-reactionwheel-1875-1_description = ジャイロスコープモジュールを複数個購入し、中型ロケットを全飛行フェーズで正確に制御できるようにしました。
     #LOC_RestockPlus_restock-reactionwheel-1875-1_tags = restock cmg command control fly gyro moment react stab steer torque magic_spinny_thing
 
     // RCS
 
-    #LOC_RestockPlus_restock-rcs-block-multi-2_title =  RV-105-A RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-multi-2_description = An angled variant of the RV-105 RCS block, available in multiple configurations.
+    #LOC_RestockPlus_restock-rcs-block-multi-2_title = RV-105-A RCS スラスターブロック
+    #LOC_RestockPlus_restock-rcs-block-multi-2_description = RV-105のRCSブロックに角度をつけた派生型です。複数のコンフィギュレーションを選択できます。
     #LOC_RestockPlus_restock-rcs-block-multi-2_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint four quad triple three dual two rcs
-    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_title =  RV-1X-A RCS Thruster Block
-    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_description = An angled variant of the RV-1X RCS block, available in multiple configurations.
+    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_title = RV-1X-A RCS スラスターブロック
+    #LOC_RestockPlus_restock-rcs-block-multi-mini-2_description = RV-1XのRCSブロックに角度をつけた派生型です。複数のコンフィギュレーションを選択できます。
     #LOC_RestockPlus_restock-rcs-block-multi-mini-2_tags = restock cluster control dock maneuver manoeuvre react rendezvous rotate stab steer translate five quint four quad triple three dual two rcs
 
     #LOC_RestockPlus_rcs_variant_5x = 5-horn
@@ -173,34 +173,34 @@ Localization
     #LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_tags = restock fuel fueltank mono propellant rcs stratus
 
     // Probe
-    #LOC_RestockPlus_restock-fuel-tank-probe-1_title = PRBE-9 Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-probe-1_description = A set of four capsule-shaped tanks holding fuel for your tiny probe needs.
+    #LOC_RestockPlus_restock-fuel-tank-probe-1_title = PRBE-9 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-probe-1_description = 小型探査機に必要な燃料を入れたカプセル型タンク4個セットです。
     #LOC_RestockPlus_restock-fuel-tank-probe-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank probe lro tiny
-    #LOC_RestockPlus_restock-fuel-tank-probe-2_title = PRBE-4 Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-probe-2_description = A short collection of four spherical tanks that works well as a tiny probe propellant tank.
+    #LOC_RestockPlus_restock-fuel-tank-probe-2_title = PRBE-4 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-probe-2_description = 小型の探査機用推進剤タンクとして有効な、4つの球形タンクのショートコレクションです。
     #LOC_RestockPlus_restock-fuel-tank-probe-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank probe lro tiny
 
     // 0.625m
-    #LOC_RestockPlus_restock-fuel-tank-0625-1_title = Oscar-E Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-0625-1_description = Capping off the Oscars is this large fuel tank. Gold statue not included.
+    #LOC_RestockPlus_restock-fuel-tank-0625-1_title = オスカー-E 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-0625-1_description = アカデミー賞を締めくくるのは、この大きな燃料タンク。オスカー像は含まれません。
     #LOC_RestockPlus_restock-fuel-tank-0625-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
-    #LOC_RestockPlus_restock-fuel-tank-0625-2_title = Oscar-D Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-0625-2_description = A medium size Oscar series tank. Useful for landers or small satellite lifters.
+    #LOC_RestockPlus_restock-fuel-tank-0625-2_title = オスカー-D 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-0625-2_description = 中型のオスカーシリーズタンク。着陸機や小型衛星搭載用リフターに有効。
     #LOC_RestockPlus_restock-fuel-tank-0625-2_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
-    #LOC_RestockPlus_restock-fuel-tank-0625-3_title = Oscar-C Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-0625-3_description = A doubled Oscar B with alphabetically incremented suffix.
+    #LOC_RestockPlus_restock-fuel-tank-0625-3_title = オスカー-C 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-0625-3_description = オスカーBが2倍されて、末尾のアルファベットがインクリメントされました。
     #LOC_RestockPlus_restock-fuel-tank-0625-3_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
-    #LOC_RestockPlus_restock-fuel-tank-0625-5_title = Oscar-A Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-0625-5_description = A prequel to the Oscar B, this tank holds a fairly small amount of fuel.
+    #LOC_RestockPlus_restock-fuel-tank-0625-5_title = オスカー-A 液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-0625-5_description = オスカーBの前身となるこのタンクは、かなり少量の燃料しか入りません。
     #LOC_RestockPlus_restock-fuel-tank-0625-5_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank oscar
 
-    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title = Oscar-O Hemispherical Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_description = A tiny half-sphere of gas to get you halfway to where you need to go.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title = オスカー-O 半球型液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_description = 小さな半球に入ったガスが、あなたの目的地への片道切符です。
     #LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
 
     // 1.25m
-    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title = FL-T50-R Hemispherical Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_description = A 1.25m half-sphere that stores liquid fuel and oxidizer.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title = FL-T50-R 半球型液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_description = 液体燃料と酸化剤を貯蔵する1.25mの半球です。
     #LOC_RestockPlus_restock-fuel-tank-sphere-125-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
 
     // 1.875m
@@ -237,26 +237,26 @@ Localization
     #LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_description = A large fully fuelled adapter to step down from the large 2.5m size to a modest 1.875m size.
     #LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank
 
-    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title = FL-TX220-R Hemispherical Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_description = Hey, it's a round, hemispherical tank carrying rocket fuel - also available in several colours.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title = FL-TX220-R 半球型液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_description = へい、こいつは丸いぞ、半球型のロケット燃料タンクだ - 今なら色も選べます。
     #LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
 
     // 2.5m
-    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title = Rockomax X-200-4R Hemispherical Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_description = This fuel tank is half a sphere. It should not be used as a pool, unlike other Rockomax products
+    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title = ロコマックス X-200-4R 半球型液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_description = この燃料タンクは球体の半分です。他のロコマックス製品と異なり、プールとして使用することはできません。
     #LOC_RestockPlus_restock-fuel-tank-sphere-25-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
 
     // 3.75m
-    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title = FL-S1 RCS Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_description = A very large monopropellant tank that stores a considerable quantity of fuel in its 6 spherical pressure vessels.
+    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title = FL-S1 RCS 燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_description = 6つの球形圧力容器に相当量の燃料を貯蔵する超大型の一液型タンクです。
     #LOC_RestockPlus_restock-fuel-tank-rcs-375-1_tags = restock fuel fueltank mono propellant rcs
 
-    #LOC_RestockPlus_restock-fuel-tank-375-4_title = Kerbodyne S3-1800 Tank
-    #LOC_RestockPlus_restock-fuel-tank-375-4_description = A special compact tank filling a particular hole in Kerbodyne's heavy part lineup. Now you can make Kerosene pancakes!
+    #LOC_RestockPlus_restock-fuel-tank-375-4_title = カーボダイン S3-1800 Tank
+    #LOC_RestockPlus_restock-fuel-tank-375-4_description = カーボダインの重量級パーツラインナップの穴を埋める、特別な小型タンクです。いま、あなたは灯油ホットケーキが作れるようになりました！
     #LOC_RestockPlus_restock-fuel-tank-375-4_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank s3 1800
 
-    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title = Kerbodyne S3-900R Hemispherical Liquid Fuel Tank
-    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_description = Compared to the S3-1800, the S3-900R is rounder, more spherical, and importantly, more cut in two.
+    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title = カーボダイン S3-900R 半球形液体燃料タンク
+    #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_description = S3-1800と比較すると、S3-900Rは丸みを帯び、球形で、2つにカットされているのが重要です。
     #LOC_RestockPlus_restock-fuel-tank-sphere-375-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank round spher hemi
 
     // 5m
@@ -292,8 +292,8 @@ Localization
     // ========
 
     // 0.625m
-    #LOC_RestockPlus_restock-drone-core-0625-1_title = RC-XS1 Remote Guidance Unit
-    #LOC_RestockPlus_restock-drone-core-0625-1_description = The smallest remote guidance unit may be tiny, but it'll get you to where you need to go eventually.
+    #LOC_RestockPlus_restock-drone-core-0625-1_title = RC-XS1 遠隔操縦ユニット
+    #LOC_RestockPlus_restock-drone-core-0625-1_description = この最小の遠隔誘導装置は小さいかもしれないが、いずれは目的地にたどり着ける。
     #LOC_RestockPlus_restock-drone-core-0625-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock remote rgu
 
     // 1.25m
@@ -314,21 +314,21 @@ Localization
     #LOC_RestockPlus_restock-mk2-pod_description = The immediate successor to the Mk1 command pod, the Mk2 seats two kerbals instead of one, and has handy forward-facing windows to enable docking.
     #LOC_RestockPlus_restock-mk2-pod_tags = capsule cmg control ?eva fly gyro ?iva moment pilot space stab steer torque gemini restock
 
-    #LOC_RestockPlus_restock-drone-core-1875-1_title = RC-M001 Remote Guidance Unit
-    #LOC_RestockPlus_restock-drone-core-1875-1_description = This unit has a low sentience quotient, so you probably won't need to be careful about leaving the pod bay doors open all the time.
+    #LOC_RestockPlus_restock-drone-core-1875-1_title = RC-M001 遠隔操縦ユニット
+    #LOC_RestockPlus_restock-drone-core-1875-1_description = このユニットは感覚指数が低いので、ポッドベイのドアをずっと開けっ放しにしていても、注意する必要はおそらくないだろう。
     #LOC_RestockPlus_restock-drone-core-1875-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock remote rgu
 
     // 3.75m
-    #LOC_RestockPlus_restock-drone-core-375-1_title = RC-XL001 Remote Guidance Unit
-    #LOC_RestockPlus_restock-drone-core-375-1_description = The massive XL RGU system designed by Kerbodyne and built by STEADLER is a triumph of aerospace engineering and contains important features such as the large empty void in the center, which can be filled with anything you like. Unlike other stack RGUs, it contains powerful reaction wheels so doubles as a guidance unit.
+    #LOC_RestockPlus_restock-drone-core-375-1_title = RC-XL001 遠隔操縦ユニット
+    #LOC_RestockPlus_restock-drone-core-375-1_description = カーボダイン社が設計し、ステッドラー社が製造した巨大な遠隔操縦システムは、航空宇宙工学の勝利であり、中央の大きな空洞に好きなものを入れることができるなどの重要な特徴を備えています。他のスタック型遠隔操縦ユニットとは異なり、強力なリアクションホイールを搭載しているため、誘導装置としても機能します。
     #LOC_RestockPlus_restock-drone-core-375-1_tags = cmg command control (core fly gyro kerbnet moment probe react sas satellite space stab steer torque restock xl001 remote rgu
 
     // COUPLING
     // ========
 
     // Radial
-    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_title = TT-14 Radial Decoupler
-    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_description = It's an extra small decoupler for very small separation events.
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_title = TT-14 ラジアル型デカプラー
+    #LOC_RestockPlus_restock-decoupler-radial-tiny-1_description = 非常に小さな分離イベントに対応した超小型デカプラーです。
     #LOC_RestockPlus_restock-decoupler-radial-tiny-1_tags = restock break decouple separat split stag
 
     // 0.625m
@@ -341,8 +341,8 @@ Localization
     #LOC_RestockPlus_restock-airlock-inflatable-625-1_tags = restock berth capture connect couple dock fasten join moor shield socket inflate airlock Leonov Voskhod
 
     // 1.25m
-    #LOC_RestockPlus_restock-engineplate-125-1_title = EP-12 Engine Plate
-    #LOC_RestockPlus_restock-engineplate-125-1_description = A small plate for holding one or more engines. Includes optional boattail to protect first stage engines, or several lengths of shroud. Includes a decoupler for use with upper stages.
+    #LOC_RestockPlus_restock-engineplate-125-1_title = EP-12 エンジンプレート
+    #LOC_RestockPlus_restock-engineplate-125-1_description = 1基または複数基のエンジンを搭載するための小型プレートです。1段目のエンジンを保護するボートテールや、数種類の長さのシュラウドがオプションで付属します。上段用ステージのためのデカプラーも付属しています。
     #LOC_RestockPlus_restock-engineplate-125-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 125 1.25 Electron
 
     // 1.875m
@@ -368,8 +368,8 @@ Localization
     #LOC_RestockPlus_restock-engineplate-25-1_tags = restock engine plate shroud boattail explo break decouple seperat split pancake 25 2.5 Falcon
 
     // 3.75m
-    #LOC_RestockPlus_restock-docking-375-1_title = Clamp-O-Tron Docking Port 'Grande'
-    #LOC_RestockPlus_restock-docking-375-1_description = When the thrill of docking enormous objects in space disappears, one must logically proceed to humongous objects. This even larger docking port is the result of 6 months of R&D to define the precise meaning of the word 'humongous'.
+    #LOC_RestockPlus_restock-docking-375-1_title = クランプオートロン ドッキングポート 'グランデ'
+    #LOC_RestockPlus_restock-docking-375-1_description = 宇宙で巨大な物体をドッキングさせるスリルがなくなったら、論理的には途方もなく巨大な物体へと進まなければなりません。この巨大なドッキングポートは、「途方もなく巨大」という言葉の正確な意味を定義するために6ヶ月に及ぶ研究開発を行った結果、誕生しました。
     #LOC_RestockPlus_restock-docking-375-1_tags = restock berth capture connect couple dock fasten join moor socket clamp grande
 
     #LOC_RestockPlus_restock-engineplate-375-1_title = EP-37 Engine Plate
@@ -393,8 +393,8 @@ Localization
     // ====
 
     // 0.625m
-    #LOC_RestockPlus_restock-nosecone-0625-1_title = Miniature Rocket Nose
-    #LOC_RestockPlus_restock-nosecone-0625-1_description = A slightly more rocket-appropriate tiny nosecone, available in white and shiny metal finishes.
+    #LOC_RestockPlus_restock-nosecone-0625-1_title = ミニチュアロケットノーズ
+    #LOC_RestockPlus_restock-nosecone-0625-1_description = 華奢なロケットに適した小さなノーズコーンです。ホワイトとシャイニーメタル仕上げの2種類をご用意しました。
     #LOC_RestockPlus_restock-nosecone-0625-1_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose
 
     // 1.875m
@@ -407,8 +407,8 @@ Localization
     #LOC_RestockPlus_restock-nosecone-1875-2_tags = restock aero aircraft booster )cap drag fligh plane rocket speed stab stream nose mk18
 
     // 3.75m
-    #LOC_RestockPlus_restock-nosecone-375-1_title = Kerbodyne S3-3600 Nosecone
-    #LOC_RestockPlus_restock-nosecone-375-1_description = A specialized and monstrous nosecone with revolutionary fuel-containing capabilities.
+    #LOC_RestockPlus_restock-nosecone-375-1_title = カーボダイン S3-3600 ノーズコーン
+    #LOC_RestockPlus_restock-nosecone-375-1_description = 画期的な燃料封入機能を持つ、特殊で怪物的なノーズコーンです。
     #LOC_RestockPlus_restock-nosecone-375-1_tags = restock fuel fueltank ?lfo liquid oxidizer propellant rocket tank s3 3600 nose cone
 
     // 5m
@@ -420,8 +420,8 @@ Localization
     // ==========
 
     // 0.625m
-    #LOC_RestockPlus_restock-node-625-1_title = BZ-26 Radial Attachment Point Jr.
-    #LOC_RestockPlus_restock-node-625-1_description = After the surprise success of the BZ-52, the Maxo Construction Toys engineering team came out of hiding to reveal the new pocket model.
+    #LOC_RestockPlus_restock-node-625-1_title = BZ-26 ラジアル型アタッチメントポイント Jr.
+    #LOC_RestockPlus_restock-node-625-1_description = BZ-52の成功を受け、マクソー・ブロック玩具社の技術陣は、隠れていたポケットモデルを新たに公開しました。
     #LOC_RestockPlus_restock-node-625-1_tags = affix anchor mount secure restock
 
     // 1.25m
@@ -430,19 +430,19 @@ Localization
     #LOC_RestockPlus_restock-structural-tube-125-1_tags = restock hollow pipe tube support structur build construct struct
 
     // 1.875m
-    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_title = FL-XA30 Adapter
-    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_description = Connect two tubes of different size classes together! Oh the kerbality!
+    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_title = FL-XA30 アダプター
+    #LOC_RestockPlus_restock-adapter-flat-1875-25-1_description = 大きさの違うクラス同士のチューブをつなげる！？おう、まさにカーバリティ!
     #LOC_RestockPlus_restock-adapter-flat-1875-25-1_tags = connect frame scaffold adapt structur restock adtp
-    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_title = FL-XA15 Adapter
-    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_description = Effectively connects small sized 1.25m tubes to larger medium 1.875m tubes.
+    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_title = FL-XA15 アダプター
+    #LOC_RestockPlus_restock-adapter-flat-1875-125-1_description = 1.25mの小型チューブと1.875mの中型チューブを効果的に接続できます。
     #LOC_RestockPlus_restock-adapter-flat-1875-125-1_tags = connect frame scaffold adapt structur restock adtp
 
     #LOC_RestockPlus_restock-structural-tube-1875-1_title = TB-1875 Structural Tube
     #LOC_RestockPlus_restock-structural-tube-1875-1_description = A medium tube for the cylindrically inclined. Available in many lengths and even finishes!
     #LOC_RestockPlus_restock-structural-tube-1875-1_tags = restock hollow pipe tube support structur build construct struct
 
-    #LOC_RestockPlus_restock-node-1875-1_title = BZ-78 Radial Attachment Point
-    #LOC_RestockPlus_restock-node-1875-1_description = Development of a 1.875m docking port never received adequate funding, so management decided to cut their losses and release it unfinished as an attachment point.
+    #LOC_RestockPlus_restock-node-1875-1_title = BZ-78 ラジアル型アタッチメントポイント
+    #LOC_RestockPlus_restock-node-1875-1_description = 1.875mのドッキングポートの開発は十分な資金が得られなかったため、経営陣は損切りして未完成のままアタッチメントとしてリリースすることにしたのです。
     #LOC_RestockPlus_restock-node-1875-1_tags= affix anchor mount secure restock
 
     // 2.5m
@@ -451,12 +451,12 @@ Localization
     #LOC_RestockPlus_restock-structural-tube-25-1_tags = restock hollow pipe tube support structur build construct struct
 
     // 3.75m
-    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_title = Kerbodyne ADTP-2-3A
-    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = A gutted version of the other Kerbodyne adapter, which allows the storage of spacecraft components in its core.
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_title = カーボダイン ADTP-2-3A
+    #LOC_RestockPlus_restock-adapter-hollow-25-375-1_description = 他のカーボダインアダプターをガッチリと固定して、宇宙船の部品をコアに収納できるようにしました。
     #LOC_RestockPlus_restock-adapter-hollow-25-375-1_tags = connect frame scaffold adapt structur strut truss hollow skel carg restock adtp
 
-    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_title = Kerbodyne SKLE-2-3
-    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_description = A structural adapter for upper stages.
+    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_title = カーボダイン SKLE-2-3
+    #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_description = 上段用構造アダプターです。
     #LOC_RestockPlus_restock-adapter-skeletal-25-375-1_tags = connect frame scaffold adapt structur strut truss eus hollow skel restock skle
 
     #LOC_RestockPlus_restock-structural-tube-375-1_title = TB-375 Structural Tube
@@ -469,16 +469,16 @@ Localization
     #LOC_RestockPlus_restock-structural-tube-5-1_tags = restock hollow pipe tube support structur build construct struct
 
     // Truss
-    #LOC_RestockPlus_restock-truss-3_title = Modular Girder Segment XXL
-    #LOC_RestockPlus_restock-truss-3_description = Compete directly with other space programs in girder size contests with this new Modular Girder product.
+    #LOC_RestockPlus_restock-truss-3_title = モジュラー構造セグメント XXL
+    #LOC_RestockPlus_restock-truss-3_description = モジュラー構造という新しい製品で、構造のサイズで他の宇宙計画と直接競うことができます。
     #LOC_RestockPlus_restock-truss-3_tags = connect frame scaffold structur strut truss restock
 
-    #LOC_RestockPlus_restock-truss-adapter-0625-1_title = Modular Girder Small Adapter
-    #LOC_RestockPlus_restock-truss-adapter-0625-1_description = Generally, marketing anticipates that by providing a means for small stacks to attach cleanly to standard Modular Girders, demand for the latter will skyrocket.
+    #LOC_RestockPlus_restock-truss-adapter-0625-1_title = 小型モジュラー構造アダプター
+    #LOC_RestockPlus_restock-truss-adapter-0625-1_description = 標準的なモジュラー構造に小さなスタックをきれいに取り付ける方法を提供することで、モジュラー構造の需要が急増すると見込まれています。
     #LOC_RestockPlus_restock-truss-adapter-0625-1_tags = connect frame scaffold structur strut truss restock adapt
 
-    #LOC_RestockPlus_restock-truss-hub-1_title = Modular Girder Hub
-    #LOC_RestockPlus_restock-truss-hub-1_description = Connect many modular girder segments together in perpendicular orientations with this new product.
+    #LOC_RestockPlus_restock-truss-hub-1_title = モジュラー構造ハブ
+    #LOC_RestockPlus_restock-truss-hub-1_description = この新製品は、多数のモジュラー構造を直角方向に連結することができます。
     #LOC_RestockPlus_restock-truss-hub-1_tags = connect frame scaffold structur strut truss restock center central hub nexus
 
     // ELECTRICAL
@@ -495,21 +495,21 @@ Localization
     #LOC_RestockPlus_restock-apu_toggle = Toggle turbine
 
     // 1.875m
-    #LOC_RestockPlus_restock-battery-1875-1_title = Z-2.5K Rechargeable Battery Bank
-    #LOC_RestockPlus_restock-battery-1875-1_description = Medium battery pack for medium battery applications.
+    #LOC_RestockPlus_restock-battery-1875-1_title = Z-2.5K リチャージブル バッテリーパック
+    #LOC_RestockPlus_restock-battery-1875-1_description = 中型バッテリーが必要なアプリケーションのためのバッテリーパックです。
     #LOC_RestockPlus_restock-battery-1875-1_tags = capacitor cell charge e/c elect pack power volt watt restock battery
 
     // 3.75m
-    #LOC_RestockPlus_restock-battery-375-1_title = Z-10K Rechargeable Battery Bank
-    #LOC_RestockPlus_restock-battery-375-1_description = A gigantic battery pack for the largest rockets. Special on this model, Zaltronic includes mishap insurance - the first time your drop your battery, it will be replaced for free! However, the battery is not user-serviceable.
+    #LOC_RestockPlus_restock-battery-375-1_title = Z-10K リチャージブル バッテリーパック
+    #LOC_RestockPlus_restock-battery-375-1_description = 最大級のロケットに対応する巨大なバッテリーパックです。このモデルは、ザルトニック社が特別に災難保険に加入しており、初めてバッテリーを落下させた場合、無料で交換します。ただし、バッテリーはユーザーによる修理はできません。
     #LOC_RestockPlus_restock-battery-375-1_tags = capacitor cell charge e/c elect pack power volt watt restock 10k battery
 
     // PAYLOAD
     // =======
 
     // 0.625m
-    #LOC_RestockPlus_restock-fairing-base-0625-1_title = AE-FF0 Airstream Protective Shell (0.625m)
-    #LOC_RestockPlus_restock-fairing-base-0625-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! This protective shell is an even tinier size available from FLOOYD.
+    #LOC_RestockPlus_restock-fairing-base-0625-1_title = AE-FF0 対空力保護シェル (0.625m)
+    #LOC_RestockPlus_restock-fairing-base-0625-1_description = ロケットを安全にカービンに帰還させるための方法を模索していたフルーイド流体力学研究所のエンジニアに対し、重要なペイロードやステージ間エリアを保護するシェルを作るための、2次元入力駆動の手続き型構造に関する大規模な研究に資金が提供されました。保護シェルには機体をより空気力学的にし、貴重なロケット燃料を節約するという利点もあります。フルーイド流体力学研究所からはさらに小さいサイズのものが発売されています。
     #LOC_RestockPlus_restock-fairing-base-0625-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 625
 
     // 1.25m
@@ -523,8 +523,8 @@ Localization
     #LOC_RestockPlus_restock-fairing-base-1875-1_description = While the Kerbals at Mission Control were still figuring out how to get their rockets back down to Kerbin safely, the research engineers at FLOOYD were quickly realising that protecting parts on ascent was just as important. Heavy research into two-dimensional-input driven procedural construction was then funded with the hopes of making protective shells for important payloads and interstage areas of the crafts. The protective shells also have the benefit of making the craft more aerodynamic, hopefully saving on precious rocket fuel! As a result of budget schedule realignments, this protective shell has recently become available.
     #LOC_RestockPlus_restock-fairing-base-1875-1_tags = restock aero )cap cargo cone contain drag fairing hollow inter nose payload protect rocket shroud stage (stor transport 875
 
-    #LOC_RestockPlus_restock-service-bay-1875-1_title = Service Bay (1.875m)
-    #LOC_RestockPlus_restock-service-bay-1875-1_description = A medium sized heat resistant service bay, ideal for protecting delicate instruments or stowing small service components such as RCS tanks, batteries, etc.
+    #LOC_RestockPlus_restock-service-bay-1875-1_title = 1.875m サービスベイ
+    #LOC_RestockPlus_restock-service-bay-1875-1_description = 中型の耐熱サービスベイ。デリケートな機器の保護や、RCSタンク、バッテリーなどの小型部品の格納に最適です。
     #LOC_RestockPlus_restock-service-bay-1875-1_tags = restock bus contain heat hollow protect (stor therm
 
     #LOC_RestockPlus_restock-service-module-1875-1_title = Service Module (1.875m)
@@ -540,63 +540,63 @@ Localization
     // =======
 
     // Radial
-    #LOC_RestockPlus_restock-materialbay-radial-1_title = SC-9001R Radial Science Jr.
-    #LOC_RestockPlus_restock-materialbay-radial-1_description = The radial variant of the Science Jr. has the same set of experiments as the regular Science Jr. Material Bay, but in a convenient, radial-mountable package. Recommended for ages 4-8. Small parts inside make it not suitable for small children.
+    #LOC_RestockPlus_restock-materialbay-radial-1_title = SC-9001R ラジアル型サイエンス Jr.
+    #LOC_RestockPlus_restock-materialbay-radial-1_description = サイエンスJr.のラジアル型は、通常のサイエンスJr.と同じ実験セットで、ラジアルマウント可能な便利なパッケージになっています。対象年齢は4～8歳です。内部の部品が小さいため、小さなお子様には不向きです。
     #LOC_RestockPlus_restock-materialbay-radial-1_tags = bay experiment lab material research radial sandwich kracken kraken restock
 
     // 0.625m
-    #LOC_RestockPlus_restock-goocanister-625-1_title = Mystery Goo™ Inline Containment Unit
-    #LOC_RestockPlus_restock-goocanister-625-1_description = After an unfortunate accident where a technician attempted to stack delicate machinery on the classic Mystery Goo™ canister, FLOOYD Dynamics Labs saw a market opportunity for a version with a flat top and bottom.
+    #LOC_RestockPlus_restock-goocanister-625-1_title = Goo™ インライン格納ユニット
+    #LOC_RestockPlus_restock-goocanister-625-1_description = ある技術者が Goo™ 容器の上に繊細な機械を積み上げようとした際に起きた不幸な事故をきっかけに、フルーイド流体力学研究所は上下がフラットなバージョンの市場機会を見いだしました。
     #LOC_RestockPlus_restock-goocanister-625-1_tags = experiment research science 0.625 restock mystery goo inline
 
-    #LOC_RestockPlus_restock-sciencebox-inline-1_title = Experiment Return Unit
-    #LOC_RestockPlus_restock-sciencebox-inline-1_description = Since science experiments kept getting destroyed before being recovered, our kerbal engineers designed the Experiment Return Unit in a conical shape to better survive the rigors of atmospheric reentry. Heat shield sold separately.
+    #LOC_RestockPlus_restock-sciencebox-inline-1_title = 実験結果帰還ユニット
+    #LOC_RestockPlus_restock-sciencebox-inline-1_description = 科学実験の結果が回収される前に破壊されることが多いため、当社のエンジニアは大気圏再突入時の過酷な環境に耐えられるよう、円錐形の実験結果帰還ユニットを設計しました。耐熱シールドは別売りです。
     #LOC_RestockPlus_restock-sciencebox-inline-1_tags = experiment research science recovery reentry restock .625 1.25 inline
 
     // COMMUNICATIONS
     // ==============
 
-    #LOC_RestockPlus_restock-relay-radial-2_title = HG-20 High Gain Antenna
-    #LOC_RestockPlus_restock-relay-radial-2_description = A longer range version of the HG-5 that can handle either direct communications or short range relays, using 4 different dishes.
+    #LOC_RestockPlus_restock-relay-radial-2_title = HG-20 ハイゲインアンテナ
+    #LOC_RestockPlus_restock-relay-radial-2_description = HG-5の長距離版で、4種類のお皿を使い分け、直接通信と短距離リレーに対応します。
     #LOC_RestockPlus_restock-relay-radial-2_tags = relay antenna radial science transmit data Apollo restock hg 20
 
-    #LOC_RestockPlus_restock-antenna-stack-2_title = Communotron DTS-J1
-    #LOC_RestockPlus_restock-antenna-stack-2_description = A fixed mount version of the popular DTS-M1 antenna. this version is a more traditional dish, giving it better efficiency at the expense of higher mass.
+    #LOC_RestockPlus_restock-antenna-stack-2_title = コミュトロン DTS-J1
+    #LOC_RestockPlus_restock-antenna-stack-2_description = DTS-M1アンテナの固定マウントバージョンです。このバージョンはより伝統的なアンテナであり、質量と引き換えに効率向上を実現しています。
     #LOC_RestockPlus_restock-antenna-stack-2_tags = antenna radial transmit data dish Juno restock communotron dts j1
 
-    #LOC_RestockPlus_restock-antenna-stack-3_title = Communotron HG-61
-    #LOC_RestockPlus_restock-antenna-stack-3_description = After developing the venerable HG-55, one of our marketing people came up with the idea of a budget version for small probes. The HG-61 removes the fancy extending arm, while still providing the same great communication range of its predecessor, making it perfect for building deep space probes on a budget.
+    #LOC_RestockPlus_restock-antenna-stack-3_title = コミュトロン HG-61
+    #LOC_RestockPlus_restock-antenna-stack-3_description = HG-55を開発した後、当社のマーケティング担当者は、小型探査機用の廉価版を思いつきました。HG-61は、従来のHG-55と同様に通信距離を確保しつつ、アームを伸ばした廉価版で、低コストな深宇宙探査機を作るのに最適です。
     #LOC_RestockPlus_restock-antenna-stack-3_tags = antenna radial transmit data dish Galileo TDRS restock communotron hg 61
 
     // LADDERS
     // =======
 
-    #LOC_RestockPlus_restock-ladder-static-2_title = Pegasus II Mobility Enhancer
-    #LOC_RestockPlus_restock-ladder-static-2_description = A logical extension of the Pegasus I, the Pegasus II however does not extend but is twice as long, allowing for longer, more dramatic climbing sequences.
+    #LOC_RestockPlus_restock-ladder-static-2_title = ペガサス II 機動性向上装置
+    #LOC_RestockPlus_restock-ladder-static-2_description = ペガサスIの延長線上にあるペガサスIIは、延長機能はありませんが長さが2倍になり、より長く、よりドラマチックなクライミングを可能にします。
     #LOC_RestockPlus_restock-ladder-static-2_tags = ascend climb descend ladder rung safe step restock
 
-    #LOC_RestockPlus_restock-ladder-static-3_title = Pegasus III Mobility Enhancer
-    #LOC_RestockPlus_restock-ladder-static-3_description = A much needed enhancement to a mobility enhancement. It is very long.
+    #LOC_RestockPlus_restock-ladder-static-3_title = ペガサス III 機動性向上装置
+    #LOC_RestockPlus_restock-ladder-static-3_description = 機動性向上のために必要なものです。とても長いです。
     #LOC_RestockPlus_restock-ladder-static-3_tags = ascend climb descend ladder rung safe step restock
 
     // RESOURCE
     // ========
 
     // 1.875m
-    #LOC_RestockPlus_restock-oretank-1875-1_title = Medium Holding Tank
-    #LOC_RestockPlus_restock-oretank-1875-1_description = A medium tank that can be used for storing raw materials. Warranty void if used to store snacks.
+    #LOC_RestockPlus_restock-oretank-1875-1_title = 中型貯蔵タンク
+    #LOC_RestockPlus_restock-oretank-1875-1_description = 原材料の貯蔵に使用できる中型タンクです。スナック菓子の保存に使用した場合、保証は無効となります。
     #LOC_RestockPlus_restock-oretank-1875-1_tags = black isru mine )mining (ore resource store restock
 
     // 3.75m
-    #LOC_RestockPlus_restock-oretank-375-1_title = Jumbo Holding Tank
-    #LOC_RestockPlus_restock-oretank-375-1_description = A very large tank that can be used for storing raw materials. The manufacturer denies any claims that it has been re-purposed from a local farm
+    #LOC_RestockPlus_restock-oretank-375-1_title = 超大型貯蔵タンク
+    #LOC_RestockPlus_restock-oretank-375-1_description = 原材料の貯蔵に使える超大型タンク。田舎の農場を再利用しているとのクレームに対し、メーカーは否定しています。
     #LOC_RestockPlus_restock-oretank-375-1_tags = black isru mine )mining (ore resource store restock
 
     // GROUND
     // ======
 
-    #LOC_RestockPlus_restock-wheel-1-T_title = Rovemax Model S2-T
-    #LOC_RestockPlus_restock-wheel-1-T_description = A modified rover wheel that is rotated 90°, ideal for tricycles or other unusually shaped vehicles.
+    #LOC_RestockPlus_restock-wheel-1-T_title = ローブマックス モデル S2-T
+    #LOC_RestockPlus_restock-wheel-1-T_description = ローバーホイールを90°回転させた改造品で、三輪車など異形の乗り物に最適です。
     #LOC_RestockPlus_restock-wheel-1-T_tags = )car drive ground roll rover wheel tricycle restock
 
     #LOC_RestockPlus_restock-wheel-4_title = Rovemax Model M0


### PR DESCRIPTION
I have added Japanese translations of the titles and descriptions of the parts of RestockPlus.
This translation is based on the machine translation (DeepL), with some modifications to match the tone used in the game.
Some parts could not be seen in the game, so their descriptions have not been translated.

Original text:
私はRestockPlusのパーツ類のタイトルと説明文の日本語訳を追加しました。
この翻訳は機械翻訳(DeepL)をベースとして、ゲーム内で使用されている口調に合わせて多少修正を加えています。
一部のパーツはゲーム内で見ることができなかったので、それらの説明文は翻訳していません。