### PR TITLE
Properly replace new MH 1.25m engine plate art assets

### DIFF
--- a/Distribution/Restock/GameData/ReStock/PatchesMH/Coupling/restock-mh-engineplates.cfg
+++ b/Distribution/Restock/GameData/ReStock/PatchesMH/Coupling/restock-mh-engineplates.cfg
@@ -1,9 +1,507 @@
 // Patches applying art changes to Making History engine plates
 // Contents:
+// - EP-12 Engine Plate (EnginePlate5)
 // - EP-18 Engine Plate (EnginePlate1p5)
 // - EP-25 Engine Plate (EnginePlate2)
 // - EP-37 Engine Plate (EnginePlate3)
 // - EP-50 Engine Plate (EnginePlate4)
+
+// EP-12 Engine Plate
+@PART[EnginePlate5]:HAS[~RestockIgnore[*]]:FOR[000_ReStock] {
+    @author = Andrew Cassidy (Cinebox) and Chris Adderley (Nertea)
+    !MODEL,* {}
+    MODEL 
+    {
+        model = ReStock/Assets/Coupling/restock-engineplate-125-1
+        texture = blank, ReStock/Assets/Structural/restock-structural-tubes-1
+        texture = blank-n, ReStock/Assets/Structural/restock-structural-tubes-1-n
+    }
+
+    // this is the same as the stock value in KSP 1.9.x, but since KSP 1.8.x 
+    // has different mass values, the variant masses below result in negative mass.
+    // This prevents that from happening, at the expense of slightly affecting part balance
+    // when ReStock is used with 1.8.x
+    @mass = 0.062
+
+    !MODULE[ModulePartVariants] {}
+    MODULE
+    {
+        name = ModulePartVariants
+        baseVariant = Long
+        baseMass = 0
+        baseCost = 0
+        useProceduralDragCubes = true
+        VARIANT
+        {
+            name = Short
+            mass = -0.02
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-short // Short
+            primaryColor = #3a562a
+            secondaryColor = #999999
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = true
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = true
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -0.675, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium-Short
+            mass = -0.015
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-med-short // Medium-Short
+            primaryColor = #3a562a
+            secondaryColor = #999999
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = true
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = true
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.3, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium
+            mass = -0.01
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-med // Medium
+            primaryColor = #3a562a
+            secondaryColor = #999999
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = true
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = true
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.925, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium-Long
+            mass = -0.005
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-med-long // Medium-Long
+            primaryColor = #3a562a
+            secondaryColor = #999999
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = true
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = true
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -2.55, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Long
+            mass = 0
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-long // Long
+            primaryColor = #3a562a
+            secondaryColor = #999999
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = true
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = true
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -3.8, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }   
+        VARIANT
+        {
+            name = Short-Orange
+            mass = -0.02
+            cost = 0
+            displayName = #LOC_Restock_variant-tube-length-short-alt // Short (Alternate)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = Orange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = true
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = true
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -0.675, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium-Short-Orange
+            mass = -0.015
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-med-short-alt // Medium-Short (Alternate)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = Orange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = true
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = true
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.3, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium-Orange
+            mass = -0.01
+            cost = 0
+            displayName = #LOC_Restock_variant-tube-length-med-alt // Medium (Alternate)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = Orange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = true
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = true
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.925, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Medium-Long-Orange
+            mass = -0.005
+            cost = 0
+            displayName = #LOC_Restock_variant-tube-length-med-long-alt // Medium-Long (Alternate)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = Orange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = true
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = true
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -2.55, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Long-Orange
+            mass = 0
+            cost = 0
+            displayName =  #LOC_Restock_variant-tube-length-long-alt // Long (Alternate)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = Orange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = true
+                Boattail-125-Colliders = false
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = false
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = true
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -3.8, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Boattail-Dark
+            mass = -0.015
+            cost = 50
+            displayName = #LOC_Restock_variant-engine_boattail_dark // Boattail (Dark)
+            primaryColor = #4c4f47
+            secondaryColor = #4c4f47
+            themeName = Dark
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = true
+                Boattail-125-Dark = true
+                Boattail-125-White = false
+                Boattail-125-Orange = false
+                Shroud1xDummy = true
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.30, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Boattail-White
+            mass = -0.015
+            cost = 50
+            displayName = #LOC_Restock_variant-engine_boattail_white // Boattail (White)
+            primaryColor = #ffffff
+            secondaryColor = #ffffff
+            themeName = White
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = true
+                Boattail-125-Dark = false
+                Boattail-125-White = true
+                Boattail-125-Orange = false
+                Shroud1xDummy = true
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.30, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+        VARIANT
+        {
+            name = Boattail-Orange
+            mass = -0.015
+            cost = 50
+            displayName = #LOC_Restock_variant-engine_boattail_grey-orange // Boattail (Orange/Grey)
+            primaryColor = #f49841
+            secondaryColor = #4c4f47
+            themeName = GrayAndOrange
+            sizeGroup = GroupB
+            GAMEOBJECTS
+            {
+                Engineplate-125-White = false
+                Engineplate-125-Orange = false
+                Boattail-125-Colliders = true
+                Boattail-125-Dark = false
+                Boattail-125-White = false
+                Boattail-125-Orange = true
+                Shroud1xDummy = true
+                Shroud1x0 = false
+                Shroud1x1 = false
+                Shroud1x2 = false
+                Shroud1x3 = false
+                Shroud1x4 = false
+                Shroud1x0-Orange = false
+                Shroud1x1-Orange = false
+                Shroud1x2-Orange = false
+                Shroud1x3-Orange = false
+                Shroud1x4-Orange = false
+            }
+            NODES
+            {
+                node_stack_bottom = 0.0, -1.30, 0.0, 0.0, -1.0, 0.0, 1
+            }
+        }
+    }
+
+    !MODULE[ModuleJettison] {}
+    MODULE
+    {
+        name = ModuleJettison
+        jettisonName =  Shroud1x0,Shroud1x1,Shroud1x2,Shroud1x3,Shroud1x4,Shroud1x0-Orange,Shroud1x1-Orange,Shroud1x2-Orange,Shroud1x3-Orange,Shroud1x4-Orange,Shroud1xDummy
+        bottomNodeName = bottom
+        isFairing = True
+        jettisonedObjectMass = 0.1
+        jettisonForce = 5
+        jettisonDirection = 0 0 1
+        stagingEnabled = false
+        useMultipleDragCubes = false
+    } 
+}
 
 // EP-18 Engine Plate
 @PART[EnginePlate1p5]:HAS[~RestockIgnore[*]]:FOR[000_ReStock]

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Coupling/125/restock-engineplate-125-1.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Parts/Coupling/125/restock-engineplate-125-1.cfg
@@ -14,6 +14,8 @@ PART
   rescaleFactor = 1.0
   node_stack_top = 0.0, 0.1, 0.0, 0.0, 1.0, 0.0, 1
   node_stack_bottom = 0.0, 0, 0.0, 0.0, -1.0, 0.0, 1, 0, 0, 1, 0
+  /// Flag to disable this part if MH is installed
+  MHReplacement = True
   TechRequired = advConstruction
   entryCost = 2200
   cost = 200


### PR DESCRIPTION
KSP Version 1.12 added a 1.25m Engine Plate to stock Making history, which restock doesn't currently account for, resulting in the stock engine plate showing up along with the restock plus version. This patch corrects that so that the MH version has its art replaced with the restock plus version.