### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/Distribution/Restock/GameData/ReStock/Localization/ru.cfg
+++ b/Distribution/Restock/GameData/ReStock/Localization/ru.cfg
@@ -1,8 +1,8 @@
 // Предлагаемый формат:
 // #LOC_Restock_partconfigname_fieldname
 // например.
-// # LOC_Restock_restock-engine-375-3_title = ...
-// # LOC_Restock_restock-engine-375-3_description = ...
+// #LOC_Restock_restock-engine-375-3_title = ...
+// #LOC_Restock_restock-engine-375-3_description = ...
 
 Localization
 {
@@ -13,149 +13,149 @@ Localization
     #LOC_Restock_scanner_screen_off = Выключить дисплей
     #LOC_Restock_scanner_screen_toggle = Вкл./выкл. дисплей
 
-    # LOC_Restock_variant-engine_size0 = 0,625 м
-    # LOC_Restock_variant-engine_size0_white = 0,625 м (Белый кожух)
-    # LOC_Restock_variant-engine_size0_grey-orange = 0,625 м (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_size1 = 1,25 м
-    # LOC_Restock_variant-engine_size1_white = 1,25 м (Белый кожух)
-    # LOC_Restock_variant-engine_size1_grey-orange = 1,25 м (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_size1p5 = 1,875 м
-    # LOC_Restock_variant-engine_size1p5_white = 1,875 м (Белый кожух)
-    # LOC_Restock_variant-engine_size1p5_grey-orange = 1,875 м (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_size2 = 2,5 м
-    # LOC_Restock_variant-engine_size2_white = 2,5 м (Белый кожух)
-    # LOC_Restock_variant-engine_size2_grey-orange = 2,5 м (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_size3 = 3,75 м
-    # LOC_Restock_variant-engine_compact = Компактный
-    # LOC_Restock_variant-engine_compact_white = Компактный (Белый кожух)
-    # LOC_Restock_variant-engine_compact_grey-orange = Компактный (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_radial = Радиальный
-    # LOC_Restock_variant-engine_boattail = Хвостовая часть
-    # LOC_Restock_variant-engine_boattail_white = Хвостовая часть (Белая)
-    # LOC_Restock_variant-engine_boattail_grey-orange = Хвостовая часть (Оранжевая/серая)
-    # LOC_Restock_variant-engine_boattail_orange = Хвостовая часть (Оранжевая)
-    # LOC_Restock_variant-engine_boattail_metal = Хвостовая часть (Металлик)
-    # LOC_Restock_variant-engine_boattail_dark = Хвостовая часть (Темная)
-    # LOC_Restock_variant-engine_boattail_size1 = Хвостовая часть (1,25 м)
-    # LOC_Restock_variant-engine_boattail_size1p5 = Хвостовая часть (1,875 м)
-    # LOC_Restock_variant-engine_boattail_size1_white = Хвостовая часть (1,25 м, белая)
-    # LOC_Restock_variant-engine_boattail_size1p5_white = Хвостовая часть (1,875 м, белая)
-    # LOC_Restock_variant-engine_boattail_size1_grey-orange = Хвостовая часть (1,25 м, оранжевая/серая)
-    # LOC_Restock_variant-engine_boattail_size1p5_grey-orange = Хвостовая часть (1,875 м, оранжевая/серая)
-    # LOC_Restock_variant-engine_tankbutt_size2_white = Крепление к баку (2,5 м, белый)
-    # LOC_Restock_variant-engine_tankbutt_size2_grey-orange = Крепление к баку (2,5 м, оранжевый/серый)
-    # LOC_Restock_variant-engine_singlebell_compact = Одно сопло, Компактный
-    # LOC_Restock_variant-engine_singlebell_compact_white = Одно сопло, компактный вариант (Белый кожух)
-    # LOC_Restock_variant-engine_singlebell_compact_grey-orange = Одно сопло, компактный вариант (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_singlebell = Одно сопло
-    # LOC_Restock_variant-engine_singlebell_white = Одно сопло (белый кожух)
-    # LOC_Restock_variant-engine_singlebell_grey-orange = Одно сопло (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_quadbell = Четыре сопла
-    # LOC_Restock_variant-engine_quadbell_white = Четыре сопла (Белый кожух)
-    # LOC_Restock_variant-engine_quadbell_grey-orange = Четыре сопла (Оранжевый/серый кожух)
-    # LOC_Restock_variant-engine_quadbell_compact = Четыре сопла, Компактный
-    # LOC_Restock_variant-engine_quadbell_compact_white = Четыре сопла, Компактный (Белый кожух)
-    # LOC_Restock_variant-engine_quadbell_compact_grey-orange = Четыре сопла, Компактный (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_size0 = 0,625 м
+    #LOC_Restock_variant-engine_size0_white = 0,625 м (Белый кожух)
+    #LOC_Restock_variant-engine_size0_grey-orange = 0,625 м (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_size1 = 1,25 м
+    #LOC_Restock_variant-engine_size1_white = 1,25 м (Белый кожух)
+    #LOC_Restock_variant-engine_size1_grey-orange = 1,25 м (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_size1p5 = 1,875 м
+    #LOC_Restock_variant-engine_size1p5_white = 1,875 м (Белый кожух)
+    #LOC_Restock_variant-engine_size1p5_grey-orange = 1,875 м (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_size2 = 2,5 м
+    #LOC_Restock_variant-engine_size2_white = 2,5 м (Белый кожух)
+    #LOC_Restock_variant-engine_size2_grey-orange = 2,5 м (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_size3 = 3,75 м
+    #LOC_Restock_variant-engine_compact = Компактный
+    #LOC_Restock_variant-engine_compact_white = Компактный (Белый кожух)
+    #LOC_Restock_variant-engine_compact_grey-orange = Компактный (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_radial = Радиальный
+    #LOC_Restock_variant-engine_boattail = Хвостовая часть
+    #LOC_Restock_variant-engine_boattail_white = Хвостовая часть (Белая)
+    #LOC_Restock_variant-engine_boattail_grey-orange = Хвостовая часть (Оранжевая/серая)
+    #LOC_Restock_variant-engine_boattail_orange = Хвостовая часть (Оранжевая)
+    #LOC_Restock_variant-engine_boattail_metal = Хвостовая часть (Металлик)
+    #LOC_Restock_variant-engine_boattail_dark = Хвостовая часть (Темная)
+    #LOC_Restock_variant-engine_boattail_size1 = Хвостовая часть (1,25 м)
+    #LOC_Restock_variant-engine_boattail_size1p5 = Хвостовая часть (1,875 м)
+    #LOC_Restock_variant-engine_boattail_size1_white = Хвостовая часть (1,25 м, белая)
+    #LOC_Restock_variant-engine_boattail_size1p5_white = Хвостовая часть (1,875 м, белая)
+    #LOC_Restock_variant-engine_boattail_size1_grey-orange = Хвостовая часть (1,25 м, оранжевая/серая)
+    #LOC_Restock_variant-engine_boattail_size1p5_grey-orange = Хвостовая часть (1,875 м, оранжевая/серая)
+    #LOC_Restock_variant-engine_tankbutt_size2_white = Крепление к баку (2,5 м, белый)
+    #LOC_Restock_variant-engine_tankbutt_size2_grey-orange = Крепление к баку (2,5 м, оранжевый/серый)
+    #LOC_Restock_variant-engine_singlebell_compact = Одно сопло, Компактный
+    #LOC_Restock_variant-engine_singlebell_compact_white = Одно сопло, компактный вариант (Белый кожух)
+    #LOC_Restock_variant-engine_singlebell_compact_grey-orange = Одно сопло, компактный вариант (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_singlebell = Одно сопло
+    #LOC_Restock_variant-engine_singlebell_white = Одно сопло (белый кожух)
+    #LOC_Restock_variant-engine_singlebell_grey-orange = Одно сопло (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_quadbell = Четыре сопла
+    #LOC_Restock_variant-engine_quadbell_white = Четыре сопла (Белый кожух)
+    #LOC_Restock_variant-engine_quadbell_grey-orange = Четыре сопла (Оранжевый/серый кожух)
+    #LOC_Restock_variant-engine_quadbell_compact = Четыре сопла, Компактный
+    #LOC_Restock_variant-engine_quadbell_compact_white = Четыре сопла, Компактный (Белый кожух)
+    #LOC_Restock_variant-engine_quadbell_compact_grey-orange = Четыре сопла, Компактный (Оранжевый/серый кожух)
 
-    # LOC_Restock_variant-engine_boattail_size2_white = Хвостовая часть (2,5 м, белая)
-    # LOC_Restock_variant-engine_boattail_size2_grey-orange = Хвостовая часть (2,5 м, оранжевая/серая)
-    # LOC_Restock_variant-engine_boattail_size3_white = Хвостовая часть (3,75 м, белая)
-    # LOC_Restock_variant-engine_boattail_size3_grey-orange = Хвостовая часть (3,75 м, оранжевая/серая)
+    #LOC_Restock_variant-engine_boattail_size2_white = Хвостовая часть (2,5 м, белая)
+    #LOC_Restock_variant-engine_boattail_size2_grey-orange = Хвостовая часть (2,5 м, оранжевая/серая)
+    #LOC_Restock_variant-engine_boattail_size3_white = Хвостовая часть (3,75 м, белая)
+    #LOC_Restock_variant-engine_boattail_size3_grey-orange = Хвостовая часть (3,75 м, оранжевая/серая)
 
-    # LOC_Restock_variant-engine_shroud_white = Белый кожух
-    # LOC_Restock_variant-engine_shroud_grey-orange = Металлический кожух
+    #LOC_Restock_variant-engine_shroud_white = Белый кожух
+    #LOC_Restock_variant-engine_shroud_grey-orange = Металлический кожух
 
-    # LOC_Restock_variant-engine_shroud = Кожух
-    # LOC_Restock_variant-engine_shroud_wide = Широкий кожух
-    # LOC_Restock_variant-engine_docking = Стыковочный порт
+    #LOC_Restock_variant-engine_shroud = Кожух
+    #LOC_Restock_variant-engine_shroud_wide = Широкий кожух
+    #LOC_Restock_variant-engine_docking = Стыковочный порт
 
-    # LOC_Restock_variant-mount_classic = Классический
-    # LOC_Restock_variant-mount_classic_white = Классический (Белый кожух)
-    # LOC_Restock_variant-mount_classic_grey-orange = Классический (Оранжевый/серый кожух)
-    # LOC_Restock_variant-mount_truss = Каркас
-    # LOC_Restock_variant-mount_compact = Компактный
-    # LOC_Restock_variant-mount_mounted = С креплением
+    #LOC_Restock_variant-mount_classic = Классический
+    #LOC_Restock_variant-mount_classic_white = Классический (Белый кожух)
+    #LOC_Restock_variant-mount_classic_grey-orange = Классический (Оранжевый/серый кожух)
+    #LOC_Restock_variant-mount_truss = Каркас
+    #LOC_Restock_variant-mount_compact = Компактный
+    #LOC_Restock_variant-mount_mounted = С креплением
 
-    # LOC_Restock_variant-gold-truss = Золотой (Каркас)
-    # LOC_Restock_variant-silver-truss = Серебряный (Каркас)
+    #LOC_Restock_variant-gold-truss = Золотой (Каркас)
+    #LOC_Restock_variant-silver-truss = Серебряный (Каркас)
 
-    # LOC_Restock_variant-engine_pod-orange = Корпус (оранжевый)
-    # LOC_Restock_variant-engine_pod-gray = Корпус (серый)
+    #LOC_Restock_variant-engine_pod-orange = Корпус (оранжевый)
+    #LOC_Restock_variant-engine_pod-gray = Корпус (серый)
 
-    # LOC_Restock_variant-antenna_size0 = 0,625 м
-    # LOC_Restock_variant-antenna_size1 = 1,25 м
-    # LOC_Restock_variant-antenna_truss = Каркас
-    # LOC_Restock_variant-antenna_compact = Компактная
-    # LOC_Restock_variant-antenna_radial = Радиальная
-    # LOC_Restock_variant-antenna_radial_reverse = Радиальная (в противоположную сторону)
-    # LOC_Restock_variant-antenna_axial = Осевая
-    # LOC_Restock_variant-antenna_axial_reverse = Осевая (в противоположную сторону)
+    #LOC_Restock_variant-antenna_size0 = 0,625 м
+    #LOC_Restock_variant-antenna_size1 = 1,25 м
+    #LOC_Restock_variant-antenna_truss = Каркас
+    #LOC_Restock_variant-antenna_compact = Компактная
+    #LOC_Restock_variant-antenna_radial = Радиальная
+    #LOC_Restock_variant-antenna_radial_reverse = Радиальная (в противоположную сторону)
+    #LOC_Restock_variant-antenna_axial = Осевая
+    #LOC_Restock_variant-antenna_axial_reverse = Осевая (в противоположную сторону)
 
-    # LOC_Restock_variant-telescope_shielded = Экранированный
-    # LOC_Restock_variant-telescope_bare = Без экрана
+    #LOC_Restock_variant-telescope_shielded = Экранированный
+    #LOC_Restock_variant-telescope_bare = Без экрана
 
-    # LOC_Restock_variant-pod_bare = Без покрытия
-    # LOC_Restock_variant-pod_fabric_green = Зеленое покрытие
-    # LOC_Restock_variant-pod_fabric_beige = Бежевое покрытие
-    # LOC_Restock_variant-pod_fabric_white = Белое покрытие
+    #LOC_Restock_variant-pod_bare = Без покрытия
+    #LOC_Restock_variant-pod_fabric_green = Зеленое покрытие
+    #LOC_Restock_variant-pod_fabric_beige = Бежевое покрытие
+    #LOC_Restock_variant-pod_fabric_white = Белое покрытие
 
-    # LOC_Restock_variant-wheel_broken = Поврежденное
-    # LOC_Restock_variant-wheel_bare = Без крыла
+    #LOC_Restock_variant-wheel_broken = Поврежденное
+    #LOC_Restock_variant-wheel_bare = Без крыла
 
-    # LOC_Restock_variant-surface_metal = Металлик
-    # LOC_Restock_variant-surface_basic = Базовый
-    # LOC_Restock_variant-surface_truss = Балка
-    # LOC_Restock_variant-surface_warningStripes = Сигнальные полосы
-    # LOC_Restock_variant-surface_thermalblankets = Теплоизоляция
-    # LOC_Restock_variant-surface_yellow = Желтый
-    # LOC_Restock_variant-surface_black = Черный
-    # LOC_Restock_variant-surface_white = Белый
-    # LOC_Restock_variant-surface_blue = Синий
+    #LOC_Restock_variant-surface_metal = Металлик
+    #LOC_Restock_variant-surface_basic = Базовый
+    #LOC_Restock_variant-surface_truss = Балка
+    #LOC_Restock_variant-surface_warningStripes = Сигнальные полосы
+    #LOC_Restock_variant-surface_thermalblankets = Теплоизоляция
+    #LOC_Restock_variant-surface_yellow = Желтый
+    #LOC_Restock_variant-surface_black = Черный
+    #LOC_Restock_variant-surface_white = Белый
+    #LOC_Restock_variant-surface_blue = Синий
 
-    # LOC_Restock_variant-strut_classic_metal = Металлик
-    # LOC_Restock_variant-strut_classic_white = Белый
-    # LOC_Restock_variant-strut_compact_metal = Металлик (компактный)
-    # LOC_Restock_variant-strut_compact_white = Белый (компактный)
+    #LOC_Restock_variant-strut_classic_metal = Металлик
+    #LOC_Restock_variant-strut_classic_white = Белый
+    #LOC_Restock_variant-strut_compact_metal = Металлик (компактный)
+    #LOC_Restock_variant-strut_compact_white = Белый (компактный)
     
-    # LOC_Restock_variant-decoupler_metal = Металлик
-    # LOC_Restock_variant-decoupler_grey-orange = Оранжевый/серый
+    #LOC_Restock_variant-decoupler_metal = Металлик
+    #LOC_Restock_variant-decoupler_grey-orange = Оранжевый/серый
 
-    # LOC_Restock_variant-service-bay-opaque = Сплошная перегородка
-    # LOC_Restock_variant-service-bay-transparent = Каркасная перегородка
-    # LOC_Restock_variant-service-bay-hollow = Без перегородки
-    # LOC_Restock_variant-service-bay-open = Открыть
-    # LOC_Restock_variant-service-bay-tunnel = Стыковочный туннель
-    # LOC_Restock_variant-service-bay-shelves = Полки
+    #LOC_Restock_variant-service-bay-opaque = Сплошная перегородка
+    #LOC_Restock_variant-service-bay-transparent = Каркасная перегородка
+    #LOC_Restock_variant-service-bay-hollow = Без перегородки
+    #LOC_Restock_variant-service-bay-open = Открыть
+    #LOC_Restock_variant-service-bay-tunnel = Стыковочный туннель
+    #LOC_Restock_variant-service-bay-shelves = Полки
 
-    # LOC_Restock_variant-heat-shield-black = Черный
-    # LOC_Restock_variant-heat-shield-brown = Классический
-    # LOC_Restock_variant-heat-shield-red = Неокрашенный
+    #LOC_Restock_variant-heat-shield-black = Черный
+    #LOC_Restock_variant-heat-shield-brown = Классический
+    #LOC_Restock_variant-heat-shield-red = Неокрашенный
 
-    # LOC_Restock_variant-linear-rcs-pod = С корпусом
-    # LOC_Restock_variant-linear-rcs-bare = Без корпуса
+    #LOC_Restock_variant-linear-rcs-pod = С корпусом
+    #LOC_Restock_variant-linear-rcs-bare = Без корпуса
 
-    # LOC_Restock_variant-stayputnik-pod = С креплением
-    # LOC_Restock_variant-stayputnik-bare = Без крепления
-    # LOC_Restock_variant-probe-gold = Золотой
-    # LOC_Restock_variant-probe-silver = Серебряный
-    # LOC_Restock_variant-probe-bare = Базовый
+    #LOC_Restock_variant-stayputnik-pod = С креплением
+    #LOC_Restock_variant-stayputnik-bare = Без крепления
+    #LOC_Restock_variant-probe-gold = Золотой
+    #LOC_Restock_variant-probe-silver = Серебряный
+    #LOC_Restock_variant-probe-bare = Базовый
 
-    # LOC_Restock_variant-radiator_basic = Базовый
-    # LOC_Restock_variant-radiator_flat = Плоский
-    # LOC_Restock_variant-radiator_compact = Компактный
+    #LOC_Restock_variant-radiator_basic = Базовый
+    #LOC_Restock_variant-radiator_flat = Плоский
+    #LOC_Restock_variant-radiator_compact = Компактный
 
-    # LOC_Restock_variant-tube-length-short = Короткая
-    # LOC_Restock_variant-tube-length-med-short = Средне-короткая
-    # LOC_Restock_variant-tube-length-med = Средняя
-    # LOC_Restock_variant-tube-length-med-long = Средне-длинная
-    # LOC_Restock_variant-tube-length-long = Длинная
+    #LOC_Restock_variant-tube-length-short = Короткая
+    #LOC_Restock_variant-tube-length-med-short = Средне-короткая
+    #LOC_Restock_variant-tube-length-med = Средняя
+    #LOC_Restock_variant-tube-length-med-long = Средне-длинная
+    #LOC_Restock_variant-tube-length-long = Длинная
 
-    # LOC_Restock_variant-tube-length-short-alt = Короткая (альтернативный вариант)
-    # LOC_Restock_variant-tube-length-med-short-alt = Средне-короткая (альтернативный вариант)
-    # LOC_Restock_variant-tube-length-med-alt = Средняя (альтернативный вариант)
-    # LOC_Restock_variant-tube-length-med-long-alt = Средне-длинная (альтернативный вариант)
-    # LOC_Restock_variant-tube-length-long-alt = Длинная (альтернативный вариант)
+    #LOC_Restock_variant-tube-length-short-alt = Короткая (альтернативный вариант)
+    #LOC_Restock_variant-tube-length-med-short-alt = Средне-короткая (альтернативный вариант)
+    #LOC_Restock_variant-tube-length-med-alt = Средняя (альтернативный вариант)
+    #LOC_Restock_variant-tube-length-med-long-alt = Средне-длинная (альтернативный вариант)
+    #LOC_Restock_variant-tube-length-long-alt = Длинная (альтернативный вариант)
 
-    # LOC_Restock_description-FuelCellArray = Зачем использовать только один маленький топливный элемент, когда можно установить три больших? Сборка из трех топливных элементов идеально подходит для ситуаций, когда вам нужен большой источник бесперебойного питания. Как и меньший топливный элемент, эта сборка работает путем преобразования топлива и окислителя в электрическую энергию.
+    #LOC_Restock_description-FuelCellArray = Зачем использовать только один маленький топливный элемент, когда можно установить три больших? Сборка из трех топливных элементов идеально подходит для ситуаций, когда вам нужен большой источник бесперебойного питания. Как и меньший топливный элемент, эта сборка работает путем преобразования топлива и окислителя в электрическую энергию.
   }
 }

--- a/Distribution/Restock/GameData/ReStock/Patches/Electrical/restock-lights.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Electrical/restock-lights.cfg
@@ -42,7 +42,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -90,7 +90,6 @@
     canPitch = true
     pitchAxisName = X
     pitchMin = 0
-    pitchMin = 0
     pitchMax = 180
   }
   MODULE
@@ -102,7 +101,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -162,7 +161,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -210,7 +209,6 @@
     canPitch = true
     pitchAxisName = X
     pitchMin = 0
-    pitchMin = 0
     pitchMax = 180
   }
   !MODULE[ModulePartVariants] {}
@@ -223,7 +221,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -278,7 +276,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -348,7 +346,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -417,7 +415,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000
@@ -486,7 +484,7 @@
     VARIANT
     {
       name = Dark
-      displayName #autoLOC_8007117
+      displayName = #autoLOC_8007117
       themeName = Dark
       primaryColor = #000000
       secondaryColor = #000000

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-25.cfg
@@ -121,7 +121,7 @@
   {
     @name = ModuleEnginesFX
     %runningEffectName = fx-poodle-running
-  }s
+  }
   !MODULE[FXModuleLookAtConstraint] {}
   MODULE
   {

--- a/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-375.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Engine/restock-engines-liquid-375.cfg
@@ -8,7 +8,7 @@
 {
   @author = Chris Adderley (Nertea)
   !mesh = DELETE
-  !MODEL = {}
+  !MODEL {}
   MODEL
   {
     model = ReStock/Assets/Engine/restock-engine-rhino-1
@@ -20,7 +20,6 @@
     cube = 0, 15.48,0.7679,2.678, 15.48,0.7679,2.743, 11.07,0.9882,0.3025, 11.06,0.7086,4, 15.48,0.7679,2.678, 15.48,0.7679,2.743, 0.002109,-0.5297,-0.002108, 5.308,4.086,5.308
     cube = 1, 11.59,0.7684,2.41, 11.59,0.7684,2.426, 11,0.5,3.35, 11,0.5,2.257, 11.59,0.7685,2.41, 11.59,0.7681,2.41, 0,-0.8842,0, 3.765,3.374,3.765
   }
-  #node_stack_bottom02 = 0.0, -2.536873, 0.0, 0.0, -1.0, 0.0, 3
   %node_attach = 0.0, 1.487975, 0.0, 0.0, 1.0, 0.0, 3
   @attachRules = 1,1,1,0,0
   !EFFECTS {}
@@ -272,7 +271,7 @@
 {
   @author = Chris Adderley (Nertea)
   !mesh = DELETE
-  !MODEL = {}
+  !MODEL {}
   MODEL
   {
     model = ReStock/Assets/Engine/restock-engine-mammoth-1

--- a/Distribution/Restock/GameData/ReStock/Patches/Structural/restock-structural-truss.cfg
+++ b/Distribution/Restock/GameData/ReStock/Patches/Structural/restock-structural-truss.cfg
@@ -387,7 +387,6 @@
       displayName = #LOC_Restock_variant-surface_thermalblankets
       primaryColor = #ffffff
       GAMEOBJECTS
-      GAMEOBJECTS
       {
         PanelBasic =  false
         PanelHollow = false
@@ -502,7 +501,6 @@
       name = Blankets
       displayName = #LOC_Restock_variant-surface_thermalblankets
       primaryColor = #ffffff
-      GAMEOBJECTS
       GAMEOBJECTS
       {
         PanelXLBasic =  false

--- a/Distribution/Restock/GameData/ReStock/Props/Hatches/RS_HTCH_625.cfg
+++ b/Distribution/Restock/GameData/ReStock/Props/Hatches/RS_HTCH_625.cfg
@@ -7,6 +7,6 @@ PROP
   {
     model = ReStock/Props/Hatches/RS_HTCH_625
   }
+  proxy = 0, 0, 0,    0.6, 0.1, 0.6,   1, 0, 0
 }
 
-proxy = 0, 0, 0,    0.6, 0.1, 0.6,   1, 0, 0

--- a/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Airlock_Green.cfg
+++ b/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Airlock_Green.cfg
@@ -7,6 +7,6 @@ PROP
   {
     model = ReStock/Props/Lights/RS_LGHT_Airlock_Green
   }
+  proxy = 0, 0, 0,    0.10, 0.15, 0.07,   1, 0, 0
 }
 
-proxy = 0, 0, 0,    0.10, 0.15, 0.07,   1, 0, 0

--- a/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Airlock_Red.cfg
+++ b/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Airlock_Red.cfg
@@ -7,6 +7,6 @@ PROP
   {
     model = ReStock/Props/Lights/RS_LGHT_Airlock_Red
   }
+  proxy = 0, 0, 0,    0.10, 0.15, 0.07,   1, 0, 0
 }
 
-proxy = 0, 0, 0,    0.10, 0.15, 0.07,   1, 0, 0

--- a/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Box_1.cfg
+++ b/Distribution/Restock/GameData/ReStock/Props/Lights/RS_LGHT_Box_1.cfg
@@ -9,21 +9,21 @@ PROP
   }
 
   //MODULE
-  {
-    name = InternalButtonLight
-
-    buttonName = enable_BOXCOLLIDER
-    defaultValue = true
-
-    lightName = SpotLight
-    lightColor = 1,1,1
-    lightIntensityOn = 0.75
-    lightIntensityOff = 0
-
-    useButtonColor = true
-    buttonColorOn = 1,1,1
-    buttonColorOff = 0,0,0
-  }
+  //{
+  //  name = InternalButtonLight
+  //
+  //  buttonName = enable_BOXCOLLIDER
+  //  defaultValue = true
+  //
+  //  lightName = SpotLight
+  //  lightColor = 1,1,1
+  //  lightIntensityOn = 0.75
+  //  lightIntensityOff = 0
+  //
+  //  useButtonColor = true
+  //  buttonColorOn = 1,1,1
+  //  buttonColorOff = 0,0,0
+  //}
+  proxy = 0, 0, 0,    0.06, 0.15, 0.07,   1, 0, 0
 }
 
-proxy = 0, 0, 0,    0.06, 0.15, 0.07,   1, 0, 0

--- a/Distribution/RestockPlus/GameData/ReStockPlus/Localization/es-es.cfg
+++ b/Distribution/RestockPlus/GameData/ReStockPlus/Localization/es-es.cfg
@@ -303,7 +303,7 @@ Localization
     #LOC_RestockPlus_restock-decoupler-1875-1_title = Desacoplador TD-18
     #LOC_RestockPlus_restock-decoupler-1875-1_description = Este desacoplador de pila es una herramienta de tamaño mediano para dividir cohetes.
     #LOC_RestockPlus_restock-decoupler-1875-1_tags = restock break decouple explo separat split
-    l
+
     #LOC_RestockPlus_restock-decoupler-1875-truss-1_title = Desacoplador de armadura TD-18T
     #LOC_RestockPlus_restock-decoupler-1875-truss-1_description = Este es un desacoplador con brocas huecas, adecuado para motores de preparación en caliente cuando divide su cohete en dos.
     #LOC_RestockPlus_restock-decoupler-1875-truss-1_tags = restock break decouple explo kerbodyne separat split


### PR DESCRIPTION
Hi, @ChrisAdderley!

I'm using ReStock to test some cfg parser code for KSP-CKAN/CKAN#3525, and I found a few minor syntax errors; descriptions/explanations below.
This pull request fixes them.

### `ru.cfg`

- Extra spaces inside of localization keys after the `#`, probably results in the Russian translation not working in-game

### `restock-lights.cfg`

- Missing `=` after `displayName`, probably results in those variants not having working display names
- Duplicate `pitchMin` properties, probably no impact

### `restock-engines-liquid-25.cfg`

- Extra `s` character after close brace (maybe an attempt to press <kbd>Ctrl+s</kbd> without enough force on <kbd>Ctrl</kbd>?), probably no impact

### `restock-engines-liquid-375.cfg`

- `=` on two lines trying to delete `MODEL` nodes, which means MM will instead try to delete a key with name `MODEL` instead of a node, impact uncertain depending on how bad it is to have two `MODEL` nodes in a `PART`
- A key starting with `#` that looks like the intent was to comment it out, now changed to `//`

### `restock-structural-truss.cfg`

- Duplicated `GAMEOBJECTS` node headers without the node contents, probably no impact

### `RS_HTCH_625.cfg`, `RS_LGHT_Airlock_Green.cfg`, `RS_LGHT_Airlock_Red.cfg`

This is where I anticipate some possible controversy.

- `proxy` key set outside of any config node, now moved into the `PROP`
  I checked stock, and this _is_ present there; it appears the loader for props doesn't use the proper `ConfigNode` parser but instead basically greps the lines of the file looking for the values it cares about. However, this ad hoc mini-parser _does_ appear to also allow "correct" syntax, so this should be OK to fix. (I would submit a fix pull request for stock if I had that option. :stuck_out_tongue:)

### `RS_LGHT_Box_1.cfg`

- Same `proxy` fix as above
- An incompletely commented out `MODULE` node results in a bare `{...}` sequence, now fully commented out
